### PR TITLE
Feature/pyokemon 30 event list genre

### DIFF
--- a/event/src/main/java/com/pyokemon/event/EventApplication.java
+++ b/event/src/main/java/com/pyokemon/event/EventApplication.java
@@ -4,7 +4,7 @@ import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication(scanBasePackages = {"com.pyokemon"})
+@SpringBootApplication(scanBasePackages = {"com.pyokemon"},exclude = {org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class})
 @MapperScan("com.pyokemon.event.repository")
 public class EventApplication {
   public static void main(String[] args) {

--- a/event/src/main/java/com/pyokemon/event/controller/EventController.java
+++ b/event/src/main/java/com/pyokemon/event/controller/EventController.java
@@ -6,13 +6,7 @@ import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.pyokemon.common.dto.ResponseDto;
 import com.pyokemon.event.dto.EventDetailResponseDTO;
@@ -57,5 +51,13 @@ public class EventController {
   public ResponseEntity<EventDetailResponseDTO> getEventDetail(@PathVariable Long eventId) {
     EventDetailResponseDTO dto = eventService.getEventDetailByEventId(eventId);
     return ResponseEntity.ok(dto);
+  }
+
+  //장르별 리스트 조회
+  @GetMapping("/eventlist")
+  public List<EventItemResponseDTO> getConcertsByPage(@RequestParam(defaultValue = "콘서트") String genre, @RequestParam(defaultValue = "1") int page) {
+    int limit = 8;
+    int offset = (page - 1) * limit;
+    return eventScheduleService.getConcertsByPage(genre, offset, limit);
   }
 }

--- a/event/src/main/java/com/pyokemon/event/controller/EventController.java
+++ b/event/src/main/java/com/pyokemon/event/controller/EventController.java
@@ -54,10 +54,9 @@ public class EventController {
   }
 
   //장르별 리스트 조회
-  @GetMapping("/eventlist")
-  public List<EventItemResponseDTO> getConcertsByPage(@RequestParam(defaultValue = "콘서트") String genre, @RequestParam(defaultValue = "1") int page) {
-    int limit = 8;
-    int offset = (page - 1) * limit;
-    return eventScheduleService.getConcertsByPage(genre, offset, limit);
+  @GetMapping
+  public List<EventItemResponseDTO> getConcertsByPage(@RequestParam(defaultValue = "콘서트") String genre, @RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "8") int size  ) {
+    int offset = (page - 1) * size;
+    return eventScheduleService.getConcertsByPage(genre, offset, size);
   }
 }

--- a/event/src/main/java/com/pyokemon/event/dto/EventItemResponseDTO.java
+++ b/event/src/main/java/com/pyokemon/event/dto/EventItemResponseDTO.java
@@ -14,6 +14,8 @@ public class EventItemResponseDTO {
   private Long eventId;
   private Long venueId;
   private String genre;
+  private Integer total;
+  private String thumbnailUrl;
   private LocalDateTime ticketOpenAt;
   private LocalDateTime eventDate;
 

--- a/event/src/main/java/com/pyokemon/event/dto/EventItemResponseDTO.java
+++ b/event/src/main/java/com/pyokemon/event/dto/EventItemResponseDTO.java
@@ -13,6 +13,7 @@ public class EventItemResponseDTO {
   private Long eventScheduleId;
   private Long eventId;
   private Long venueId;
+  private String genre;
   private LocalDateTime ticketOpenAt;
   private LocalDateTime eventDate;
 

--- a/event/src/main/java/com/pyokemon/event/repository/EventScheduleRepository.java
+++ b/event/src/main/java/com/pyokemon/event/repository/EventScheduleRepository.java
@@ -8,6 +8,7 @@ import org.apache.ibatis.annotations.Mapper;
 
 import com.pyokemon.event.dto.EventItemResponseDTO;
 import com.pyokemon.event.entity.EventSchedule;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface EventScheduleRepository {
@@ -19,5 +20,7 @@ public interface EventScheduleRepository {
   Optional<EventSchedule> findById(Long id);
 
   Long save(EventSchedule eventSchedule);
+
+  List<EventItemResponseDTO> selectEventList(@Param("genre") String genre, @Param("limit") int limit, @Param("offset") int offset);
 
 }

--- a/event/src/main/java/com/pyokemon/event/repository/EventScheduleRepository.java
+++ b/event/src/main/java/com/pyokemon/event/repository/EventScheduleRepository.java
@@ -23,4 +23,7 @@ public interface EventScheduleRepository {
 
   List<EventItemResponseDTO> selectEventList(@Param("genre") String genre, @Param("limit") int limit, @Param("offset") int offset);
 
+  int getTotalCountByGenre(@Param("genre") String genre);
+
+
 }

--- a/event/src/main/java/com/pyokemon/event/service/EventScheduleService.java
+++ b/event/src/main/java/com/pyokemon/event/service/EventScheduleService.java
@@ -24,6 +24,15 @@ public class EventScheduleService {
   }
 
   public List<EventItemResponseDTO> getConcertsByPage(String genre, int offset, int limit) {
-    return eventScheduleRepository.selectEventList(genre, limit, offset);
+    List<EventItemResponseDTO> events = eventScheduleRepository.selectEventList(genre, limit, offset);
+    int total = eventScheduleRepository.getTotalCountByGenre(genre);
+
+    for (EventItemResponseDTO event : events) {
+      event.setTotal(total); // 👈 각 아이템에 total 주입
+    }
+
+    return events;
   }
+
+
 }

--- a/event/src/main/java/com/pyokemon/event/service/EventScheduleService.java
+++ b/event/src/main/java/com/pyokemon/event/service/EventScheduleService.java
@@ -22,4 +22,8 @@ public class EventScheduleService {
   public List<EventItemResponseDTO> getTicketsToBeOpened() {
     return eventScheduleRepository.selectTicketsToBeOpened();
   }
+
+  public List<EventItemResponseDTO> getConcertsByPage(String genre, int offset, int limit) {
+    return eventScheduleRepository.selectEventList(genre, limit, offset);
+  }
 }

--- a/event/src/main/resources/mapper/EventScheduleMapper.xml
+++ b/event/src/main/resources/mapper/EventScheduleMapper.xml
@@ -41,7 +41,8 @@
             es.ticket_open_at,
             es.event_date,
             e.title AS title,
-            v.venue_name AS venue_name
+            v.venue_name AS venue_name,
+            e.thumbnail_url
         FROM tb_event_schedule es
                  JOIN tb_event e ON es.event_id = e.event_id
                  JOIN tb_venue v ON es.venue_id = v.venue_id
@@ -58,7 +59,8 @@
             es.event_date,
             e.title AS title,
             v.venue_name AS venue_name,
-            e.genre
+            e.genre,
+            e.thumbnail_url
         FROM tb_event_schedule es
                  JOIN tb_event e ON es.event_id = e.event_id
                  JOIN tb_venue v ON es.venue_id = v.venue_id
@@ -74,7 +76,9 @@
             es.ticket_open_at,
             es.event_date,
             e.title AS title,
-            v.venue_name AS venue_name
+            v.venue_name AS venue_name,
+            e.genre,
+            e.thumbnail_url
         FROM tb_event_schedule es
                  JOIN tb_event e ON es.event_id = e.event_id
                  JOIN tb_venue v ON es.venue_id = v.venue_id
@@ -83,5 +87,16 @@
             e.genre = #{genre}
             LIMIT #{limit} OFFSET #{offset}
     </select>
+
+    <select id="getTotalCountByGenre" resultType="int">
+        SELECT COUNT(*)
+        FROM tb_event_schedule es
+                 JOIN tb_event e ON es.event_id = e.event_id
+                 JOIN tb_venue v ON es.venue_id = v.venue_id
+        WHERE
+            e.status = 'APPROVED'
+          AND e.genre = #{genre}
+    </select>
+
 
 </mapper>

--- a/event/src/main/resources/mapper/EventScheduleMapper.xml
+++ b/event/src/main/resources/mapper/EventScheduleMapper.xml
@@ -57,7 +57,8 @@
             es.ticket_open_at,
             es.event_date,
             e.title AS title,
-            v.venue_name AS venue_name
+            v.venue_name AS venue_name,
+            e.genre
         FROM tb_event_schedule es
                  JOIN tb_event e ON es.event_id = e.event_id
                  JOIN tb_venue v ON es.venue_id = v.venue_id

--- a/event/src/main/resources/mapper/EventScheduleMapper.xml
+++ b/event/src/main/resources/mapper/EventScheduleMapper.xml
@@ -65,5 +65,22 @@
             LIMIT 8
     </select>
 
+    <select id="selectEventList" resultType="EventItemResponseDTO">
+        SELECT
+            es.event_schedule_id,
+            es.event_id,
+            es.venue_id,
+            es.ticket_open_at,
+            es.event_date,
+            e.title AS title,
+            v.venue_name AS venue_name
+        FROM tb_event_schedule es
+                 JOIN tb_event e ON es.event_id = e.event_id
+                 JOIN tb_venue v ON es.venue_id = v.venue_id
+        WHERE
+            e.status = 'APPROVED' AND
+            e.genre = #{genre}
+            LIMIT #{limit} OFFSET #{offset}
+    </select>
 
 </mapper>

--- a/event/src/test/event.postman_collection.json
+++ b/event/src/test/event.postman_collection.json
@@ -1,0 +1,209 @@
+{
+	"info": {
+		"_postman_id": "3e69f891-cf58-456a-9aa9-01077cb82d6d",
+		"name": "event",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "33007023",
+		"_collection_link": "https://blue-moon-913939.postman.co/workspace/dca11d37-d81a-4ae3-8828-fbd92d9f37f6/collection/33007023-3e69f891-cf58-456a-9aa9-01077cb82d6d?action=share&source=collection_link&creator=33007023"
+	},
+	"item": [
+		{
+			"name": "전체 잔여 좌석",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8080/api/events/booking/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"api",
+						"events",
+						"booking",
+						"1"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "VIP 좌석 status",
+			"request": {
+				"method": "GET",
+				"header": []
+			},
+			"response": []
+		},
+		{
+			"name": "공연 상세 정보 조회",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8080/api/events/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"api",
+						"events",
+						"1"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "공연 정보 등록",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"tenantId\": 1,\r\n    \"title\": \"BTS 콘서트\",\r\n    \"ageLimit\": 12,\r\n    \"description\": \"BTS의 공연.\",\r\n    \"genre\": \"콘서트\",\r\n    \"thumbnailUrl\": \"\",\r\n    \"schedules\": [\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-01T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        },\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-02T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        }\r\n    ]\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8080/api/events",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"api",
+						"events"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "오늘 오픈 티켓 조회",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"tenantId\": 1,\r\n    \"title\": \"BTS 콘서트\",\r\n    \"ageLimit\": 12,\r\n    \"description\": \"BTS의 공연.\",\r\n    \"genre\": \"콘서트\",\r\n    \"thumbnailUrl\": \"\",\r\n    \"schedules\": [\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-01T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        },\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-02T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        }\r\n    ]\r\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8080/api/events/open-today",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"api",
+						"events",
+						"open-today"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "오픈 예정 티켓 조회",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"tenantId\": 1,\r\n    \"title\": \"BTS 콘서트\",\r\n    \"ageLimit\": 12,\r\n    \"description\": \"BTS의 공연.\",\r\n    \"genre\": \"콘서트\",\r\n    \"thumbnailUrl\": \"\",\r\n    \"schedules\": [\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-01T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        },\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-02T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        }\r\n    ]\r\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8080/api/events/to-be-opened",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"api",
+						"events",
+						"to-be-opened"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "장르별 공연 조회",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"tenantId\": 1,\r\n    \"title\": \"BTS 콘서트\",\r\n    \"ageLimit\": 12,\r\n    \"description\": \"BTS의 공연.\",\r\n    \"genre\": \"콘서트\",\r\n    \"thumbnailUrl\": \"\",\r\n    \"schedules\": [\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-01T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        },\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-02T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        }\r\n    ]\r\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8080/api/events/eventlist?page=1&genre=콘서트",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"api",
+						"events",
+						"eventlist"
+					],
+					"query": [
+						{
+							"key": "page",
+							"value": "1"
+						},
+						{
+							"key": "genre",
+							"value": "콘서트"
+						}
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
## ✏️ 작업 개요  
장르별 조회 기능 추가
8개씩 가져오도록 처리

## 🔨 작업 내용 상세
- EventController에  장르별 조회 리스트 API 추가 (GET)

## 🔗 관련 이슈  
- Closes #18 

## ✅ 체크리스트  
- [ ] 콘서트
- [ ] 뮤지컬
- [ ] 연급
- [ ] 클래식
- [ ] 스포츠
- [ ] 행사


## 💬 기타 참고 사항  
- GET http://localhost:8080/api/events/eventlist?page=1&genre=콘서트
