### PR TITLE
[Feature/pyokemon-47] 예매결제 api

### DIFF
--- a/event/src/main/java/com/pyokemon/event/EventApplication.java
+++ b/event/src/main/java/com/pyokemon/event/EventApplication.java
@@ -3,9 +3,11 @@ package com.pyokemon.event;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = {"com.pyokemon"},exclude = {org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class})
 @MapperScan("com.pyokemon.event.repository")
+@EnableScheduling
 public class EventApplication {
   public static void main(String[] args) {
     SpringApplication.run(EventApplication.class, args);

--- a/event/src/main/java/com/pyokemon/event/controller/BookingController.java
+++ b/event/src/main/java/com/pyokemon/event/controller/BookingController.java
@@ -3,11 +3,10 @@ package com.pyokemon.event.controller;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import com.pyokemon.event.dto.BookingRequestDto;
+import com.pyokemon.event.dto.BookingResponseDto;
 import com.pyokemon.event.dto.EventScheduleSeatResponse;
 import com.pyokemon.event.dto.SeatMapDetail;
 import com.pyokemon.event.service.BookingSeatService;
@@ -41,4 +40,11 @@ public class BookingController {
     return ResponseEntity.ok(seatMap);
   }
 
+  @PostMapping("/booking")
+  public ResponseEntity<BookingResponseDto> createBooking(
+      @RequestBody BookingRequestDto bookingRequestDto,
+      @RequestHeader("X-Auth-AccountId") Long accountId) {
+    BookingResponseDto response = bookingSeatService.createBooking(bookingRequestDto, accountId);
+    return ResponseEntity.ok(response);
+  }
 }

--- a/event/src/main/java/com/pyokemon/event/dto/BookingRequestDto.java
+++ b/event/src/main/java/com/pyokemon/event/dto/BookingRequestDto.java
@@ -1,0 +1,15 @@
+package com.pyokemon.event.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookingRequestDto {
+    private Long eventScheduleId;
+    private Long seatId;
+} 

--- a/event/src/main/java/com/pyokemon/event/dto/BookingResponseDto.java
+++ b/event/src/main/java/com/pyokemon/event/dto/BookingResponseDto.java
@@ -1,0 +1,15 @@
+package com.pyokemon.event.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookingResponseDto {
+    private Long bookingId;
+    private Long eventScheduleId;
+} 

--- a/event/src/main/java/com/pyokemon/event/dto/SeatMapDetail.java
+++ b/event/src/main/java/com/pyokemon/event/dto/SeatMapDetail.java
@@ -16,8 +16,4 @@ public class SeatMapDetail {
   public boolean isBooked() {
     return isBooked;
   }
-
-  public void setBooked(boolean booked) {
-    isBooked = booked;
-  }
 }

--- a/event/src/main/java/com/pyokemon/event/entity/Booking.java
+++ b/event/src/main/java/com/pyokemon/event/entity/Booking.java
@@ -13,13 +13,13 @@ public class Booking {
   private Long bookingId;
   private Long eventScheduleId;
   private Long seatId;
-  private Long userId;
+  private Long accountId;
   private Long paymentId;
   private Booked status;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 
   public enum Booked {
-    BOOKED, CANCELLED
+    PENDING, BOOKED, CANCELLED
   }
 }

--- a/event/src/main/java/com/pyokemon/event/repository/BookingRepository.java
+++ b/event/src/main/java/com/pyokemon/event/repository/BookingRepository.java
@@ -10,4 +10,6 @@ import com.pyokemon.event.entity.Booking;
 public interface BookingRepository {
   List<Booking> findByEventScheduleIdAndStatus(Long eventScheduleId, Booking.Booked status);
   void insert(Booking booking);
+  List<Booking> findByStatus(Booking.Booked status);
+  void delete(Booking booking);
 }

--- a/event/src/main/java/com/pyokemon/event/repository/BookingRepository.java
+++ b/event/src/main/java/com/pyokemon/event/repository/BookingRepository.java
@@ -9,4 +9,5 @@ import com.pyokemon.event.entity.Booking;
 @Mapper
 public interface BookingRepository {
   List<Booking> findByEventScheduleIdAndStatus(Long eventScheduleId, Booking.Booked status);
+  void insert(Booking booking);
 }

--- a/event/src/main/java/com/pyokemon/event/repository/BookingRepository.java
+++ b/event/src/main/java/com/pyokemon/event/repository/BookingRepository.java
@@ -9,6 +9,7 @@ import com.pyokemon.event.entity.Booking;
 @Mapper
 public interface BookingRepository {
   List<Booking> findByEventScheduleIdAndStatus(Long eventScheduleId, Booking.Booked status);
+  List<Booking> findByEventScheduleIdAndAccountId(Long eventScheduleId, Long accountId);
   void insert(Booking booking);
   List<Booking> findByStatus(Booking.Booked status);
   void delete(Booking booking);

--- a/event/src/main/java/com/pyokemon/event/service/BookingSeatService.java
+++ b/event/src/main/java/com/pyokemon/event/service/BookingSeatService.java
@@ -9,9 +9,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import com.pyokemon.common.exception.BusinessException;
+import com.pyokemon.common.exception.code.EventErrorCodes;
 import com.pyokemon.event.entity.Booking;
+import com.pyokemon.event.entity.EventSchedule;
 import com.pyokemon.event.entity.Price;
 import com.pyokemon.event.entity.Seat;
 import com.pyokemon.event.entity.SeatClass;
@@ -40,119 +43,214 @@ public class BookingSeatService {
 
   @Transactional
   public BookingResponseDto createBooking(BookingRequestDto requestDto, Long accountId) {
+    validateBookingRequest(requestDto, accountId);
+
+    EventSchedule eventSchedule = eventScheduleRepository.findById(requestDto.getEventScheduleId())
+        .orElseThrow(() -> new BusinessException("존재하지 않는 이벤트 스케줄입니다.", EventErrorCodes.SCHEDULE_NOT_FOUND));
+    Seat seat = seatRepository.findById(requestDto.getSeatId())
+        .orElseThrow(() -> new BusinessException("존재하지 않는 좌석입니다.", EventErrorCodes.SEAT_NOT_FOUND));
+    if (!seat.getVenueId().equals(eventSchedule.getVenueId())) {
+      throw new BusinessException("해당 이벤트에 속하지 않는 좌석입니다.", EventErrorCodes.SEAT_NOT_AVAILABLE);
+    }
+
     boolean isAlreadyBooked = bookingRepository.findByEventScheduleIdAndStatus(requestDto.getEventScheduleId(), Booking.Booked.BOOKED).stream()
         .anyMatch(b -> b.getSeatId().equals(requestDto.getSeatId()));
     if (isAlreadyBooked) {
-      throw new BusinessException("이미 예약된 좌석입니다.", "SEAT_ALREADY_BOOKED");
+      throw new BusinessException("이미 예약된 좌석입니다.", EventErrorCodes.SEAT_ALREADY_RESERVED);
     }
-
     boolean isPending = bookingRepository.findByEventScheduleIdAndStatus(requestDto.getEventScheduleId(), Booking.Booked.PENDING).stream()
         .anyMatch(b -> b.getSeatId().equals(requestDto.getSeatId()));
     if (isPending) {
-      throw new BusinessException("이미 예약 중인 좌석입니다.", "SEAT_ALREADY_PENDING");
+      throw new BusinessException("이미 예약 중인 좌석입니다.", EventErrorCodes.SEAT_ALREADY_RESERVED);
+    }
+    boolean hasExistingBooking = bookingRepository.findByEventScheduleIdAndAccountId(requestDto.getEventScheduleId(), accountId).stream()
+        .anyMatch(b -> b.getStatus() == Booking.Booked.BOOKED || b.getStatus() == Booking.Booked.PENDING);
+    if (hasExistingBooking) {
+      throw new BusinessException("이미 해당 이벤트에 예약이 있습니다.", EventErrorCodes.BOOKING_ALREADY_EXISTS);
     }
 
-    Booking booking = new Booking();
-    booking.setEventScheduleId(requestDto.getEventScheduleId());
-    booking.setAccountId(accountId);
-    booking.setSeatId(requestDto.getSeatId());
-    booking.setStatus(Booking.Booked.PENDING);
-    booking.setCreatedAt(LocalDateTime.now());
-    booking.setUpdatedAt(LocalDateTime.now());
-    bookingRepository.insert(booking);
+    try {
+      Booking booking = new Booking();
+      booking.setEventScheduleId(requestDto.getEventScheduleId());
+      booking.setAccountId(accountId);
+      booking.setSeatId(requestDto.getSeatId());
+      booking.setStatus(Booking.Booked.PENDING);
+      booking.setCreatedAt(LocalDateTime.now());
+      booking.setUpdatedAt(LocalDateTime.now());
+      bookingRepository.insert(booking);
 
-    return new BookingResponseDto(booking.getBookingId(), booking.getEventScheduleId());
+      log.info("예약 생성 완료: bookingId={}, eventScheduleId={}, seatId={}, accountId={}", 
+          booking.getBookingId(), booking.getEventScheduleId(), booking.getSeatId(), booking.getAccountId());
+
+      return new BookingResponseDto(booking.getBookingId(), booking.getEventScheduleId());
+    } catch (Exception e) {
+      log.error("예약 생성 중 오류 발생: eventScheduleId={}, seatId={}, accountId={}", 
+          requestDto.getEventScheduleId(), requestDto.getSeatId(), accountId, e);
+      throw new BusinessException("예약 생성 중 오류가 발생했습니다.", EventErrorCodes.EVENT_INTERNAL_ERROR);
+    }
   }
 
   public EventScheduleSeatResponse getEventScheduleSeats(Long eventScheduleId) {
-    Long venueId = getVenueId(eventScheduleId);
-    List<Seat> venueSeats = seatRepository.findByVenueId(venueId);
-    List<Booking> bookedBookings = bookingRepository.findByEventScheduleIdAndStatus(eventScheduleId, Booking.Booked.BOOKED);
-    List<Booking> pendingBookings = bookingRepository.findByEventScheduleIdAndStatus(eventScheduleId, Booking.Booked.PENDING);
-    List<Price> prices = priceRepository.findByEventScheduleId(eventScheduleId);
-    List<SeatClass> seatClasses = seatClassRepository.findAll();
+    if (eventScheduleId == null || eventScheduleId <= 0) {
+      throw new BusinessException("유효하지 않은 이벤트 스케줄 ID입니다.", EventErrorCodes.EVENT_ID_REQUIRED);
+    }
+    
+    try {
+      EventSchedule eventSchedule = eventScheduleRepository.findById(eventScheduleId)
+          .orElseThrow(() -> new BusinessException("존재하지 않는 이벤트 스케줄입니다.", EventErrorCodes.SCHEDULE_NOT_FOUND));
+      
+      Long venueId = eventSchedule.getVenueId();
+      List<Seat> venueSeats = seatRepository.findByVenueId(venueId);
+      if (venueSeats.isEmpty()) {
+        throw new BusinessException("해당 장소에 등록된 좌석이 없습니다.", EventErrorCodes.SEAT_NOT_FOUND);
+      }
+      
+      List<Booking> bookedBookings = bookingRepository.findByEventScheduleIdAndStatus(eventScheduleId, Booking.Booked.BOOKED);
+      List<Booking> pendingBookings = bookingRepository.findByEventScheduleIdAndStatus(eventScheduleId, Booking.Booked.PENDING);
+      List<Price> prices = priceRepository.findByEventScheduleId(eventScheduleId);
+      List<SeatClass> seatClasses = seatClassRepository.findAll();
 
-    Set<Long> bookedSeatIds = bookedBookings.stream()
-        .map(Booking::getSeatId)
-        .collect(Collectors.toSet());
-    bookedSeatIds.addAll(pendingBookings.stream()
-        .map(Booking::getSeatId)
-        .collect(Collectors.toSet()));
+      Set<Long> bookedSeatIds = bookedBookings.stream()
+          .map(Booking::getSeatId)
+          .collect(Collectors.toSet());
+      bookedSeatIds.addAll(pendingBookings.stream()
+          .map(Booking::getSeatId)
+          .collect(Collectors.toSet()));
 
-    Map<Long, Long> totalSeatsByClass = venueSeats.stream()
-        .collect(Collectors.groupingBy(Seat::getSeatClassId, Collectors.counting()));
+      Map<Long, Long> totalSeatsByClass = venueSeats.stream()
+          .collect(Collectors.groupingBy(Seat::getSeatClassId, Collectors.counting()));
 
-    Map<Long, Long> bookedSeatsByClass = venueSeats.stream()
-        .filter(seat -> bookedSeatIds.contains(seat.getSeatId()))
-        .collect(Collectors.groupingBy(Seat::getSeatClassId, Collectors.counting()));
+      Map<Long, Long> bookedSeatsByClass = venueSeats.stream()
+          .filter(seat -> bookedSeatIds.contains(seat.getSeatId()))
+          .collect(Collectors.groupingBy(Seat::getSeatClassId, Collectors.counting()));
 
-    Map<Long, Integer> priceMap = prices.stream()
-        .collect(Collectors.toMap(Price::getSeatClassId, Price::getPrice));
+      Map<Long, Integer> priceMap = prices.stream()
+          .collect(Collectors.toMap(Price::getSeatClassId, Price::getPrice));
 
-    List<SeatGradeRemaining> seatGradeList = seatClasses.stream()
-        .map(sc -> {
-          long total = totalSeatsByClass.getOrDefault(sc.getSeatClassId(), 0L);
-          long booked = bookedSeatsByClass.getOrDefault(sc.getSeatClassId(), 0L);
-          int remain = (int) (total - booked);
-          int price = priceMap.getOrDefault(sc.getSeatClassId(), 0);
-          return new SeatGradeRemaining(sc.getClassName(), remain, price);
-        })
-        .collect(Collectors.toList());
+      List<SeatGradeRemaining> seatGradeList = seatClasses.stream()
+          .map(sc -> {
+            long total = totalSeatsByClass.getOrDefault(sc.getSeatClassId(), 0L);
+            long booked = bookedSeatsByClass.getOrDefault(sc.getSeatClassId(), 0L);
+            int remain = (int) (total - booked);
+            int price = priceMap.getOrDefault(sc.getSeatClassId(), 0);
+            return new SeatGradeRemaining(sc.getClassName(), remain, price);
+          })
+          .collect(Collectors.toList());
 
-    return new EventScheduleSeatResponse(eventScheduleId, seatGradeList);
+      return new EventScheduleSeatResponse(eventScheduleId, seatGradeList);
+    } catch (BusinessException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("좌석 정보 조회 중 오류 발생: eventScheduleId={}", eventScheduleId, e);
+      throw new BusinessException("좌석 정보 조회 중 오류가 발생했습니다.", EventErrorCodes.EVENT_INTERNAL_ERROR);
+    }
   }
 
   public List<SeatMapDetail> getSeatMapOnlyByGrade(Long eventScheduleId, String seatGrade) {
-    Long venueId = getVenueId(eventScheduleId);
-    List<Seat> seats = seatRepository.findByVenueId(venueId);
-    List<Booking> bookedBookings = bookingRepository.findByEventScheduleIdAndStatus(eventScheduleId, Booking.Booked.BOOKED);
-    List<Booking> pendingBookings = bookingRepository.findByEventScheduleIdAndStatus(eventScheduleId, Booking.Booked.PENDING);
-    List<SeatClass> seatClasses = seatClassRepository.findAll();
-
-    Set<Long> bookedSeatIds = bookedBookings.stream()
-        .map(Booking::getSeatId)
-        .collect(Collectors.toSet());
-    bookedSeatIds.addAll(pendingBookings.stream()
-        .map(Booking::getSeatId)
-        .collect(Collectors.toSet()));
-
-    Map<Long, String> classMap = seatClasses.stream()
-        .collect(Collectors.toMap(SeatClass::getSeatClassId, SeatClass::getClassName));
-
-    List<SeatMapDetail> result = seats.stream()
-        .filter(seat -> seatGrade.equalsIgnoreCase(classMap.get(seat.getSeatClassId())))
-        .map(seat -> new SeatMapDetail(
-            seat.getSeatId(),
-            seat.getRow(),
-            seat.getCol(),
-            classMap.get(seat.getSeatClassId()),
-            bookedSeatIds.contains(seat.getSeatId())))
-        .collect(Collectors.toList());
-
-    if (result.isEmpty()) {
-      throw new BusinessException("등록된 좌석이 없습니다.", "SEAT_NOT_FOUND");
+    if (eventScheduleId == null || eventScheduleId <= 0) {
+      throw new BusinessException("유효하지 않은 이벤트 스케줄 ID입니다.", EventErrorCodes.EVENT_ID_REQUIRED);
     }
+    if (!StringUtils.hasText(seatGrade)) {
+      throw new BusinessException("좌석 등급을 입력해주세요.", EventErrorCodes.SEAT_CLASS_NOT_FOUND);
+    }
+    
+    try {
+      EventSchedule eventSchedule = eventScheduleRepository.findById(eventScheduleId)
+          .orElseThrow(() -> new BusinessException("존재하지 않는 이벤트 스케줄입니다.", EventErrorCodes.SCHEDULE_NOT_FOUND));
+      
+      Long venueId = eventSchedule.getVenueId();
+      List<Seat> seats = seatRepository.findByVenueId(venueId);
+      if (seats.isEmpty()) {
+        throw new BusinessException("해당 장소에 등록된 좌석이 없습니다.", EventErrorCodes.SEAT_NOT_FOUND);
+      }
+      
+      List<Booking> bookedBookings = bookingRepository.findByEventScheduleIdAndStatus(eventScheduleId, Booking.Booked.BOOKED);
+      List<Booking> pendingBookings = bookingRepository.findByEventScheduleIdAndStatus(eventScheduleId, Booking.Booked.PENDING);
+      List<SeatClass> seatClasses = seatClassRepository.findAll();
 
-    return result;
+      Set<Long> bookedSeatIds = bookedBookings.stream()
+          .map(Booking::getSeatId)
+          .collect(Collectors.toSet());
+      bookedSeatIds.addAll(pendingBookings.stream()
+          .map(Booking::getSeatId)
+          .collect(Collectors.toSet()));
+
+      Map<Long, String> classMap = seatClasses.stream()
+          .collect(Collectors.toMap(SeatClass::getSeatClassId, SeatClass::getClassName));
+
+      List<SeatMapDetail> result = seats.stream()
+          .filter(seat -> seatGrade.equalsIgnoreCase(classMap.get(seat.getSeatClassId())))
+          .map(seat -> new SeatMapDetail(
+              seat.getSeatId(),
+              seat.getRow(),
+              seat.getCol(),
+              classMap.get(seat.getSeatClassId()),
+              bookedSeatIds.contains(seat.getSeatId())))
+          .collect(Collectors.toList());
+
+      if (result.isEmpty()) {
+        throw new BusinessException("해당 등급의 좌석이 없습니다.", EventErrorCodes.SEAT_CLASS_NOT_FOUND);
+      }
+
+      return result;
+    } catch (BusinessException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("좌석 맵 조회 중 오류 발생: eventScheduleId={}, seatGrade={}", eventScheduleId, seatGrade, e);
+      throw new BusinessException("좌석 맵 조회 중 오류가 발생했습니다.", EventErrorCodes.EVENT_INTERNAL_ERROR);
+    }
   }
 
   @Transactional(readOnly = false)
   @Scheduled(cron = "0 */5 * * * *")
   public void deletePendingBookings() {
-    List<Booking> pendingBookings = bookingRepository.findByStatus(Booking.Booked.PENDING);
+    try {
+      List<Booking> pendingBookings = bookingRepository.findByStatus(Booking.Booked.PENDING);
 
-    if (pendingBookings.isEmpty()) return;
+      if (pendingBookings.isEmpty()) {
+        log.debug("삭제할 PENDING 예약이 없습니다.");
+        return;
+      }
 
-    for (Booking booking : pendingBookings) {
-      bookingRepository.delete(booking);
-      log.info("삭제된 예약(PENDING): bookingId={}, seatId={}, eventScheduleId={}",
-              booking.getBookingId(), booking.getSeatId(), booking.getEventScheduleId());
+      int deletedCount = 0;
+      for (Booking booking : pendingBookings) {
+        try {
+          bookingRepository.delete(booking);
+          deletedCount++;
+          log.info("삭제된 예약(PENDING): bookingId={}, seatId={}, eventScheduleId={}",
+                  booking.getBookingId(), booking.getSeatId(), booking.getEventScheduleId());
+        } catch (Exception e) {
+          log.error("예약 삭제 중 오류 발생: bookingId={}", booking.getBookingId(), e);
+        }
+      }
+      
+      log.info("PENDING 예약 삭제 완료: 총 {}개 중 {}개 삭제", pendingBookings.size(), deletedCount);
+    } catch (Exception e) {
+      log.error("PENDING 예약 삭제 작업 중 오류 발생", e);
+    }
+  }
+
+  private void validateBookingRequest(BookingRequestDto requestDto, Long accountId) {
+    if (requestDto == null) {
+      throw new BusinessException("예약 요청 정보가 없습니다.", EventErrorCodes.BOOKING_ID_REQUIRED);
+    }
+    
+    if (requestDto.getEventScheduleId() == null || requestDto.getEventScheduleId() <= 0) {
+      throw new BusinessException("유효하지 않은 이벤트 스케줄 ID입니다.", EventErrorCodes.EVENT_ID_REQUIRED);
+    }
+    
+    if (requestDto.getSeatId() == null || requestDto.getSeatId() <= 0) {
+      throw new BusinessException("유효하지 않은 좌석 ID입니다.", EventErrorCodes.SEAT_ID_REQUIRED);
+    }
+    
+    if (accountId == null || accountId <= 0) {
+      throw new BusinessException("유효하지 않은 계정 ID입니다.", EventErrorCodes.EVENT_ACCESS_DENIED);
     }
   }
 
   private Long getVenueId(Long scheduleId) {
     return eventScheduleRepository.findById(scheduleId)
-        .orElseThrow(() -> new BusinessException("존재하지 않는 이벤트 스케줄입니다.", "EVENT_SCHEDULE_NOT_FOUND"))
+        .orElseThrow(() -> new BusinessException("존재하지 않는 이벤트 스케줄입니다.", EventErrorCodes.SCHEDULE_NOT_FOUND))
         .getVenueId();
   }
 }

--- a/event/src/main/resources/db/migration/event/V1_007__Create_booking_table.sql
+++ b/event/src/main/resources/db/migration/event/V1_007__Create_booking_table.sql
@@ -2,9 +2,9 @@ CREATE TABLE tb_booking (
             booking_id BIGINT PRIMARY KEY AUTO_INCREMENT,
             event_schedule_id BIGINT NOT NULL,
             seat_id BIGINT NOT NULL,
-            user_id BIGINT NOT NULL,
-            payment_id BIGINT NOT NULL,
-            status ENUM('BOOKED', 'CANCELLED') DEFAULT 'BOOKED',
+            account_id BIGINT NOT NULL,
+            payment_id BIGINT,
+            status ENUM('PENDING', 'BOOKED', 'CANCELLED') DEFAULT 'PENDING',
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
             CONSTRAINT fk_booking_schedule FOREIGN KEY (event_schedule_id) REFERENCES tb_event_schedule(event_schedule_id),
@@ -15,4 +15,4 @@ CREATE TABLE tb_booking (
 
 CREATE INDEX idx_booking_schedule_id ON tb_booking(event_schedule_id);
 CREATE INDEX idx_booking_seat_id ON tb_booking(seat_id);
-CREATE INDEX idx_booking_user_id ON tb_booking(user_id);
+CREATE INDEX idx_booking_user_id ON tb_booking(account_id);

--- a/event/src/main/resources/mapper/BookingMapper.xml
+++ b/event/src/main/resources/mapper/BookingMapper.xml
@@ -6,16 +6,21 @@
 <mapper namespace="com.pyokemon.event.repository.BookingRepository">
 
     <select id="findByEventScheduleIdAndStatus" resultType="Booking">
-        SELECT booking_id, event_schedule_id, user_id, payment_id, status, created_at, updated_at, seat_id
+        SELECT booking_id, event_schedule_id, account_id, payment_id, status, created_at, updated_at, seat_id
         FROM tb_booking
         WHERE event_schedule_id = #{param1}
               AND status = #{param2}
     </select>
 
     <select id="findById" resultType="Booking">
-        SELECT booking_id, event_schedule_id, user_id, payment_id, status, created_at, updated_at, seat_id
+        SELECT booking_id, event_schedule_id, account_id, payment_id, status, created_at, updated_at, seat_id
         FROM tb_booking
         WHERE booking_id = #{param1}
     </select>
+
+    <insert id="insert" parameterType="Booking" useGeneratedKeys="true" keyProperty="bookingId">
+        INSERT INTO tb_booking (event_schedule_id, account_id, payment_id, status, created_at, updated_at, seat_id)
+        VALUES (#{eventScheduleId}, #{accountId}, #{paymentId}, #{status}, #{createdAt}, #{updatedAt}, #{seatId})
+    </insert>
 
 </mapper>

--- a/event/src/main/resources/mapper/BookingMapper.xml
+++ b/event/src/main/resources/mapper/BookingMapper.xml
@@ -12,6 +12,13 @@
               AND status = #{param2}
     </select>
 
+    <select id="findByEventScheduleIdAndAccountId" resultType="Booking">
+        SELECT booking_id, event_schedule_id, account_id, payment_id, status, created_at, updated_at, seat_id
+        FROM tb_booking
+        WHERE event_schedule_id = #{param1}
+              AND account_id = #{param2}
+    </select>
+
     <select id="findById" resultType="Booking">
         SELECT booking_id, event_schedule_id, account_id, payment_id, status, created_at, updated_at, seat_id
         FROM tb_booking

--- a/event/src/main/resources/mapper/BookingMapper.xml
+++ b/event/src/main/resources/mapper/BookingMapper.xml
@@ -23,4 +23,12 @@
         VALUES (#{eventScheduleId}, #{accountId}, #{paymentId}, #{status}, #{createdAt}, #{updatedAt}, #{seatId})
     </insert>
 
+    <select id="findByStatus" resultType="Booking">
+        SELECT * FROM tb_booking WHERE status = #{status}
+    </select>
+
+    <delete id="delete">
+        DELETE FROM tb_booking WHERE booking_id = #{bookingId}
+    </delete>
+
 </mapper>

--- a/event/src/test/event.postman_collection.json
+++ b/event/src/test/event.postman_collection.json
@@ -2,9 +2,9 @@
 	"info": {
 		"_postman_id": "3e69f891-cf58-456a-9aa9-01077cb82d6d",
 		"name": "event",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
 		"_exporter_id": "33007023",
-		"_collection_link": "https://blue-moon-913939.postman.co/workspace/dca11d37-d81a-4ae3-8828-fbd92d9f37f6/collection/33007023-3e69f891-cf58-456a-9aa9-01077cb82d6d?action=share&source=collection_link&creator=33007023"
+		"_collection_link": "https://blue-moon-913939.postman.co/workspace/My-Workspace~dca11d37-d81a-4ae3-8828-fbd92d9f37f6/collection/33007023-3e69f891-cf58-456a-9aa9-01077cb82d6d?action=share&source=collection_link&creator=33007023"
 	},
 	"item": [
 		{
@@ -12,20 +12,7 @@
 			"request": {
 				"method": "GET",
 				"header": [],
-				"url": {
-					"raw": "http://localhost:8080/api/events/booking/1",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"api",
-						"events",
-						"booking",
-						"1"
-					]
-				}
+				"url": "http://localhost:8081/event/api/events/booking/1"
 			},
 			"response": []
 		},
@@ -42,19 +29,7 @@
 			"request": {
 				"method": "GET",
 				"header": [],
-				"url": {
-					"raw": "http://localhost:8080/api/events/1",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"api",
-						"events",
-						"1"
-					]
-				}
+				"url": "http://localhost:8081/event/api/events/1"
 			},
 			"response": []
 		},
@@ -78,18 +53,7 @@
 						}
 					}
 				},
-				"url": {
-					"raw": "http://localhost:8080/api/events",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"api",
-						"events"
-					]
-				}
+				"url": "http://localhost:8081/event/api/events"
 			},
 			"response": []
 		},
@@ -111,19 +75,7 @@
 					"mode": "raw",
 					"raw": "{\r\n    \"tenantId\": 1,\r\n    \"title\": \"BTS 콘서트\",\r\n    \"ageLimit\": 12,\r\n    \"description\": \"BTS의 공연.\",\r\n    \"genre\": \"콘서트\",\r\n    \"thumbnailUrl\": \"\",\r\n    \"schedules\": [\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-01T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        },\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-02T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        }\r\n    ]\r\n}"
 				},
-				"url": {
-					"raw": "http://localhost:8080/api/events/open-today",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"api",
-						"events",
-						"open-today"
-					]
-				}
+				"url": "http://localhost:8081/event/api/events/open-today"
 			},
 			"response": []
 		},
@@ -145,19 +97,7 @@
 					"mode": "raw",
 					"raw": "{\r\n    \"tenantId\": 1,\r\n    \"title\": \"BTS 콘서트\",\r\n    \"ageLimit\": 12,\r\n    \"description\": \"BTS의 공연.\",\r\n    \"genre\": \"콘서트\",\r\n    \"thumbnailUrl\": \"\",\r\n    \"schedules\": [\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-01T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        },\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-02T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        }\r\n    ]\r\n}"
 				},
-				"url": {
-					"raw": "http://localhost:8080/api/events/to-be-opened",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"api",
-						"events",
-						"to-be-opened"
-					]
-				}
+				"url": "http://localhost:8081/event/api/events/to-be-opened"
 			},
 			"response": []
 		},
@@ -180,16 +120,16 @@
 					"raw": "{\r\n    \"tenantId\": 1,\r\n    \"title\": \"BTS 콘서트\",\r\n    \"ageLimit\": 12,\r\n    \"description\": \"BTS의 공연.\",\r\n    \"genre\": \"콘서트\",\r\n    \"thumbnailUrl\": \"\",\r\n    \"schedules\": [\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-01T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        },\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-02T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        }\r\n    ]\r\n}"
 				},
 				"url": {
-					"raw": "http://localhost:8080/api/events/eventlist?page=1&genre=콘서트",
+					"raw": "http://localhost:8081/event/api/events?page=1&genre=콘서트&size=8",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "8080",
+					"port": "8081",
 					"path": [
+						"event",
 						"api",
-						"events",
-						"eventlist"
+						"events"
 					],
 					"query": [
 						{
@@ -199,9 +139,42 @@
 						{
 							"key": "genre",
 							"value": "콘서트"
+						},
+						{
+							"key": "size",
+							"value": "8"
 						}
 					]
 				}
+			},
+			"response": []
+		},
+		{
+			"name": "공연 예매",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "X-Auth-AccountId",
+						"value": "1",
+						"type": "text"
+					},
+					{
+						"key": "X-Auth-Role",
+						"value": "USER",
+						"type": "text"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"eventScheduleId\": 1,\r\n  \"seatId\": 97\r\n}"
+				},
+				"url": "http://localhost:8081/event/api/events/booking"
 			},
 			"response": []
 		}

--- a/event/src/test/event.postman_collection.json
+++ b/event/src/test/event.postman_collection.json
@@ -2,7 +2,7 @@
 	"info": {
 		"_postman_id": "3e69f891-cf58-456a-9aa9-01077cb82d6d",
 		"name": "event",
-		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "33007023",
 		"_collection_link": "https://blue-moon-913939.postman.co/workspace/My-Workspace~dca11d37-d81a-4ae3-8828-fbd92d9f37f6/collection/33007023-3e69f891-cf58-456a-9aa9-01077cb82d6d?action=share&source=collection_link&creator=33007023"
 	},
@@ -12,7 +12,21 @@
 			"request": {
 				"method": "GET",
 				"header": [],
-				"url": "http://localhost:8081/event/api/events/booking/1"
+				"url": {
+					"raw": "http://localhost:8081/event/api/events/booking/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8081",
+					"path": [
+						"event",
+						"api",
+						"events",
+						"booking",
+						"1"
+					]
+				}
 			},
 			"response": []
 		},
@@ -29,7 +43,20 @@
 			"request": {
 				"method": "GET",
 				"header": [],
-				"url": "http://localhost:8081/event/api/events/1"
+				"url": {
+					"raw": "http://localhost:8081/event/api/events/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8081",
+					"path": [
+						"event",
+						"api",
+						"events",
+						"1"
+					]
+				}
 			},
 			"response": []
 		},
@@ -53,7 +80,19 @@
 						}
 					}
 				},
-				"url": "http://localhost:8081/event/api/events"
+				"url": {
+					"raw": "http://localhost:8081/event/api/events",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8081",
+					"path": [
+						"event",
+						"api",
+						"events"
+					]
+				}
 			},
 			"response": []
 		},
@@ -75,7 +114,20 @@
 					"mode": "raw",
 					"raw": "{\r\n    \"tenantId\": 1,\r\n    \"title\": \"BTS 콘서트\",\r\n    \"ageLimit\": 12,\r\n    \"description\": \"BTS의 공연.\",\r\n    \"genre\": \"콘서트\",\r\n    \"thumbnailUrl\": \"\",\r\n    \"schedules\": [\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-01T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        },\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-02T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        }\r\n    ]\r\n}"
 				},
-				"url": "http://localhost:8081/event/api/events/open-today"
+				"url": {
+					"raw": "http://localhost:8081/event/api/events/open-today",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8081",
+					"path": [
+						"event",
+						"api",
+						"events",
+						"open-today"
+					]
+				}
 			},
 			"response": []
 		},
@@ -97,7 +149,20 @@
 					"mode": "raw",
 					"raw": "{\r\n    \"tenantId\": 1,\r\n    \"title\": \"BTS 콘서트\",\r\n    \"ageLimit\": 12,\r\n    \"description\": \"BTS의 공연.\",\r\n    \"genre\": \"콘서트\",\r\n    \"thumbnailUrl\": \"\",\r\n    \"schedules\": [\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-01T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        },\r\n        {\r\n            \"venueId\": 1,\r\n            \"ticketOpenAt\": \"2026-01-01T10:00:00\",\r\n            \"eventDate\": \"2026-02-02T19:00:00\",\r\n            \"prices\": [\r\n                {\r\n                    \"seatClassId\": 1,\r\n                    \"price\": 150000\r\n                }\r\n            ]\r\n        }\r\n    ]\r\n}"
 				},
-				"url": "http://localhost:8081/event/api/events/to-be-opened"
+				"url": {
+					"raw": "http://localhost:8081/event/api/events/to-be-opened",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8081",
+					"path": [
+						"event",
+						"api",
+						"events",
+						"to-be-opened"
+					]
+				}
 			},
 			"response": []
 		},
@@ -174,7 +239,20 @@
 					"mode": "raw",
 					"raw": "{\r\n  \"eventScheduleId\": 1,\r\n  \"seatId\": 97\r\n}"
 				},
-				"url": "http://localhost:8081/event/api/events/booking"
+				"url": {
+					"raw": "http://localhost:8081/event/api/events/booking",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8081",
+					"path": [
+						"event",
+						"api",
+						"events",
+						"booking"
+					]
+				}
 			},
 			"response": []
 		}

--- a/event/src/test/java/com/pyokemon/event/service/BookingSeatServiceTest.java
+++ b/event/src/test/java/com/pyokemon/event/service/BookingSeatServiceTest.java
@@ -1,179 +1,421 @@
 package com.pyokemon.event.service;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
+import com.pyokemon.common.exception.BusinessException;
+import com.pyokemon.common.exception.code.EventErrorCodes;
+import com.pyokemon.event.dto.*;
+import com.pyokemon.event.entity.*;
+import com.pyokemon.event.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.pyokemon.common.exception.BusinessException;
-import com.pyokemon.event.dto.SeatMapDetail;
-import com.pyokemon.event.entity.*;
-import com.pyokemon.event.repository.*;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class BookingSeatServiceTest {
 
-  @Mock
-  private EventScheduleRepository eventScheduleRepository;
+    @Mock
+    private EventScheduleRepository eventScheduleRepository;
+    
+    @Mock
+    private SeatRepository seatRepository;
+    
+    @Mock
+    private SeatClassRepository seatClassRepository;
+    
+    @Mock
+    private BookingRepository bookingRepository;
+    
+    @Mock
+    private PriceRepository priceRepository;
 
-  @Mock
-  private SeatRepository seatRepository;
+    @InjectMocks
+    private BookingSeatService bookingSeatService;
 
-  @Mock
-  private SeatClassRepository seatClassRepository;
+    private BookingRequestDto validBookingRequest;
+    private EventSchedule validEventSchedule;
+    private Seat validSeat;
+    private Booking validBooking;
+    private Long validAccountId = 1L;
+    private Long validEventScheduleId = 1L;
+    private Long validSeatId = 1L;
+    private Long validVenueId = 1L;
 
-  @Mock
-  private BookingRepository bookingRepository;
+    @BeforeEach
+    void setUp() {
+        validBookingRequest = new BookingRequestDto(validEventScheduleId, validSeatId);
+        
+        validEventSchedule = new EventSchedule();
+        validEventSchedule.setEventScheduleId(validEventScheduleId);
+        validEventSchedule.setVenueId(validVenueId);
+        
+        validSeat = new Seat();
+        validSeat.setSeatId(validSeatId);
+        validSeat.setVenueId(validVenueId);
+        validSeat.setSeatClassId(1L);
+        validSeat.setRow("A");
+        validSeat.setCol("1");
+        
+        validBooking = new Booking();
+        validBooking.setBookingId(1L);
+        validBooking.setEventScheduleId(validEventScheduleId);
+        validBooking.setSeatId(validSeatId);
+        validBooking.setAccountId(validAccountId);
+        validBooking.setStatus(Booking.Booked.PENDING);
+        validBooking.setCreatedAt(LocalDateTime.now());
+        validBooking.setUpdatedAt(LocalDateTime.now());
+    }
 
-  @Mock
-  private PriceRepository priceRepository;
+    @Test
+    @DisplayName("정상적인 예약 생성 테스트")
+    void createBooking_Success() {
+        when(eventScheduleRepository.findById(validEventScheduleId))
+            .thenReturn(Optional.of(validEventSchedule));
+        when(seatRepository.findById(validSeatId))
+            .thenReturn(Optional.of(validSeat));
+        when(bookingRepository.findByEventScheduleIdAndStatus(validEventScheduleId, Booking.Booked.BOOKED))
+            .thenReturn(Collections.emptyList());
+        when(bookingRepository.findByEventScheduleIdAndStatus(validEventScheduleId, Booking.Booked.PENDING))
+            .thenReturn(Collections.emptyList());
+        when(bookingRepository.findByEventScheduleIdAndAccountId(validEventScheduleId, validAccountId))
+            .thenReturn(Collections.emptyList());
+        doAnswer(invocation -> {
+            Booking booking = invocation.getArgument(0);
+            booking.setBookingId(1L);
+            return null;
+        }).when(bookingRepository).insert(any(Booking.class));
 
-  @InjectMocks
-  private BookingSeatService bookingSeatService;
+        BookingResponseDto result = bookingSeatService.createBooking(validBookingRequest, validAccountId);
 
-  @Test
-  void 좌석등급으로_좌석리스트_조회_성공() {
-    Long scheduleId = 1L;
-    Long venueId = 100L;
-    String seatGrade = "VIP";
+        assertNotNull(result);
+        assertEquals(1L, result.getBookingId());
+        assertEquals(validEventScheduleId, result.getEventScheduleId());
+        
+        verify(bookingRepository).insert(any(Booking.class));
+        verify(eventScheduleRepository).findById(validEventScheduleId);
+        verify(seatRepository).findById(validSeatId);
+    }
 
-    Seat seat1 = new Seat(1L, venueId, 10L, 1L, "A", "1", null, null);
-    Seat seat2 = new Seat(2L, venueId, 10L, 1L, "A", "2", null, null);
+    @Test
+    @DisplayName("null 예약 요청으로 예약 생성 시 예외 발생")
+    void createBooking_NullRequest_ThrowsException() {
+        BusinessException exception = assertThrows(BusinessException.class, 
+            () -> bookingSeatService.createBooking(null, validAccountId));
+        
+        assertEquals(EventErrorCodes.BOOKING_ID_REQUIRED, exception.getErrorCode());
+    }
 
-    SeatClass seatClass = new SeatClass(10L, seatGrade, null, null, null);
+    @Test
+    @DisplayName("유효하지 않은 이벤트 스케줄 ID로 예약 생성 시 예외 발생")
+    void createBooking_InvalidEventScheduleId_ThrowsException() {
+        BookingRequestDto invalidRequest = new BookingRequestDto(null, validSeatId);
 
-    EventSchedule eventSchedule =
-        EventSchedule.builder().eventScheduleId(scheduleId).venueId(venueId).build();
+        BusinessException exception = assertThrows(BusinessException.class, 
+            () -> bookingSeatService.createBooking(invalidRequest, validAccountId));
+        
+        assertEquals(EventErrorCodes.EVENT_ID_REQUIRED, exception.getErrorCode());
+    }
 
-    when(eventScheduleRepository.findById(scheduleId)).thenReturn(Optional.of(eventSchedule));
-    when(seatRepository.findByVenueId(venueId)).thenReturn(List.of(seat1, seat2));
-    when(seatClassRepository.findAll()).thenReturn(List.of(seatClass));
-    when(bookingRepository.findByEventScheduleIdAndStatus(eq(scheduleId), any()))
-        .thenReturn(Collections.emptyList());
+    @Test
+    @DisplayName("유효하지 않은 좌석 ID로 예약 생성 시 예외 발생")
+    void createBooking_InvalidSeatId_ThrowsException() {
+        BookingRequestDto invalidRequest = new BookingRequestDto(validEventScheduleId, null);
 
-    List<SeatMapDetail> result = bookingSeatService.getSeatMapOnlyByGrade(scheduleId, seatGrade);
+        BusinessException exception = assertThrows(BusinessException.class, 
+            () -> bookingSeatService.createBooking(invalidRequest, validAccountId));
+        
+        assertEquals(EventErrorCodes.SEAT_ID_REQUIRED, exception.getErrorCode());
+    }
 
-    assertEquals(2, result.size());
-    assertTrue(result.stream().allMatch(seat -> seat.getSeatGrade().equals(seatGrade)));
-  }
+    @Test
+    @DisplayName("존재하지 않는 이벤트 스케줄로 예약 생성 시 예외 발생")
+    void createBooking_NonExistentEventSchedule_ThrowsException() {
+        when(eventScheduleRepository.findById(validEventScheduleId))
+            .thenReturn(Optional.empty());
 
-  @Test
-  void 좌석등급에_해당하는_좌석이_없으면_예외발생() {
-    Long scheduleId = 2L;
-    Long venueId = 200L;
-    String seatGrade = "R";
+        BusinessException exception = assertThrows(BusinessException.class, 
+            () -> bookingSeatService.createBooking(validBookingRequest, validAccountId));
+        
+        assertEquals(EventErrorCodes.SCHEDULE_NOT_FOUND, exception.getErrorCode());
+    }
 
-    EventSchedule eventSchedule =
-        EventSchedule.builder().eventScheduleId(scheduleId).venueId(venueId).build();
+    @Test
+    @DisplayName("존재하지 않는 좌석으로 예약 생성 시 예외 발생")
+    void createBooking_NonExistentSeat_ThrowsException() {
+        when(eventScheduleRepository.findById(validEventScheduleId))
+            .thenReturn(Optional.of(validEventSchedule));
+        when(seatRepository.findById(validSeatId))
+            .thenReturn(Optional.empty());
 
-    SeatClass vipClass = new SeatClass(10L, "VIP", null, null, null);
-    Seat seat = new Seat(1L, venueId, 10L, 1L, "A", "1", null, null);
+        BusinessException exception = assertThrows(BusinessException.class, 
+            () -> bookingSeatService.createBooking(validBookingRequest, validAccountId));
+        
+        assertEquals(EventErrorCodes.SEAT_NOT_FOUND, exception.getErrorCode());
+    }
 
-    when(eventScheduleRepository.findById(scheduleId)).thenReturn(Optional.of(eventSchedule));
-    when(seatRepository.findByVenueId(venueId)).thenReturn(List.of(seat));
-    when(seatClassRepository.findAll()).thenReturn(List.of(vipClass));
-    when(bookingRepository.findByEventScheduleIdAndStatus(eq(scheduleId), any()))
-        .thenReturn(Collections.emptyList());
+    @Test
+    @DisplayName("이미 예약된 좌석으로 예약 생성 시 예외 발생")
+    void createBooking_AlreadyBookedSeat_ThrowsException() {
+        Booking bookedBooking = new Booking();
+        bookedBooking.setSeatId(validSeatId);
+        bookedBooking.setStatus(Booking.Booked.BOOKED);
+        
+        when(eventScheduleRepository.findById(validEventScheduleId))
+            .thenReturn(Optional.of(validEventSchedule));
+        when(seatRepository.findById(validSeatId))
+            .thenReturn(Optional.of(validSeat));
+        when(bookingRepository.findByEventScheduleIdAndStatus(validEventScheduleId, Booking.Booked.BOOKED))
+            .thenReturn(Arrays.asList(bookedBooking));
 
-    BusinessException ex = assertThrows(BusinessException.class, () -> {
-      bookingSeatService.getSeatMapOnlyByGrade(scheduleId, seatGrade);
-    });
+        BusinessException exception = assertThrows(BusinessException.class, 
+            () -> bookingSeatService.createBooking(validBookingRequest, validAccountId));
+        
+        assertEquals(EventErrorCodes.SEAT_ALREADY_RESERVED, exception.getErrorCode());
+    }
 
-    assertEquals("SEAT_NOT_FOUND", ex.getErrorCode());
-  }
+    @Test
+    @DisplayName("이미 예약 중인 좌석으로 예약 생성 시 예외 발생")
+    void createBooking_PendingSeat_ThrowsException() {
+        Booking pendingBooking = new Booking();
+        pendingBooking.setSeatId(validSeatId);
+        pendingBooking.setStatus(Booking.Booked.PENDING);
+        
+        when(eventScheduleRepository.findById(validEventScheduleId))
+            .thenReturn(Optional.of(validEventSchedule));
+        when(seatRepository.findById(validSeatId))
+            .thenReturn(Optional.of(validSeat));
+        when(bookingRepository.findByEventScheduleIdAndStatus(validEventScheduleId, Booking.Booked.BOOKED))
+            .thenReturn(Collections.emptyList());
+        when(bookingRepository.findByEventScheduleIdAndStatus(validEventScheduleId, Booking.Booked.PENDING))
+            .thenReturn(Arrays.asList(pendingBooking));
 
-  @Test
-  void 예약된_좌석이_표시됨() {
-    Long scheduleId = 1L;
-    Long venueId = 100L;
-    String seatGrade = "VIP";
+        BusinessException exception = assertThrows(BusinessException.class, 
+            () -> bookingSeatService.createBooking(validBookingRequest, validAccountId));
+        
+        assertEquals(EventErrorCodes.SEAT_ALREADY_RESERVED, exception.getErrorCode());
+    }
 
-    Long seatClassId = 10L;
+    @Test
+    @DisplayName("이미 해당 이벤트에 예약이 있는 경우 예외 발생")
+    void createBooking_ExistingBookingForEvent_ThrowsException() {
+        Booking existingBooking = new Booking();
+        existingBooking.setAccountId(validAccountId);
+        existingBooking.setStatus(Booking.Booked.BOOKED);
+        
+        when(eventScheduleRepository.findById(validEventScheduleId))
+            .thenReturn(Optional.of(validEventSchedule));
+        when(seatRepository.findById(validSeatId))
+            .thenReturn(Optional.of(validSeat));
+        when(bookingRepository.findByEventScheduleIdAndStatus(validEventScheduleId, Booking.Booked.BOOKED))
+            .thenReturn(Collections.emptyList());
+        when(bookingRepository.findByEventScheduleIdAndStatus(validEventScheduleId, Booking.Booked.PENDING))
+            .thenReturn(Collections.emptyList());
+        when(bookingRepository.findByEventScheduleIdAndAccountId(validEventScheduleId, validAccountId))
+            .thenReturn(Arrays.asList(existingBooking));
 
-    Seat seat1 = new Seat(1L, venueId, seatClassId, 1L, "A", "1", null, null);
-    Seat seat2 = new Seat(2L, venueId, seatClassId, 1L, "A", "2", null, null);
+        BusinessException exception = assertThrows(BusinessException.class, 
+            () -> bookingSeatService.createBooking(validBookingRequest, validAccountId));
+        
+        assertEquals(EventErrorCodes.BOOKING_ALREADY_EXISTS, exception.getErrorCode());
+    }
 
-    SeatClass seatClass = new SeatClass(seatClassId, seatGrade, null, null, null);
+    @Test
+    @DisplayName("정상적인 좌석 정보 조회 테스트")
+    void getEventScheduleSeats_Success() {
+        List<Seat> seats = Arrays.asList(validSeat);
+        List<SeatClass> seatClasses = Arrays.asList(createSeatClass(1L, "VIP"));
+        List<Price> prices = Arrays.asList(createPrice(1L, 50000));
+        
+        when(eventScheduleRepository.findById(validEventScheduleId))
+            .thenReturn(Optional.of(validEventSchedule));
+        when(seatRepository.findByVenueId(validVenueId))
+            .thenReturn(seats);
+        when(bookingRepository.findByEventScheduleIdAndStatus(validEventScheduleId, Booking.Booked.BOOKED))
+            .thenReturn(Collections.emptyList());
+        when(bookingRepository.findByEventScheduleIdAndStatus(validEventScheduleId, Booking.Booked.PENDING))
+            .thenReturn(Collections.emptyList());
+        when(priceRepository.findByEventScheduleId(validEventScheduleId))
+            .thenReturn(prices);
+        when(seatClassRepository.findAll())
+            .thenReturn(seatClasses);
 
-    EventSchedule eventSchedule =
-        EventSchedule.builder().eventScheduleId(scheduleId).venueId(venueId).build();
+        EventScheduleSeatResponse result = bookingSeatService.getEventScheduleSeats(validEventScheduleId);
 
-    Booking booked = Booking.builder().seatId(1L).eventScheduleId(scheduleId)
-        .status(Booking.Booked.valueOf("BOOKED")).build();
+        assertNotNull(result);
+        assertEquals(validEventScheduleId, result.getEventScheduleId());
+        assertEquals(1, result.getRemainingSeatsByGrade().size());
+        assertEquals("VIP", result.getRemainingSeatsByGrade().get(0).getSeatGrade());
+        assertEquals(1, result.getRemainingSeatsByGrade().get(0).getRemainingSeats());
+        assertEquals(50000, result.getRemainingSeatsByGrade().get(0).getPrice());
+    }
 
-    when(eventScheduleRepository.findById(scheduleId)).thenReturn(Optional.of(eventSchedule));
-    when(seatRepository.findByVenueId(venueId)).thenReturn(List.of(seat1, seat2));
-    when(seatClassRepository.findAll()).thenReturn(List.of(seatClass));
-    when(bookingRepository.findByEventScheduleIdAndStatus(eq(scheduleId), any()))
-        .thenReturn(List.of(booked));
+    @Test
+    @DisplayName("유효하지 않은 이벤트 스케줄 ID로 좌석 정보 조회 시 예외 발생")
+    void getEventScheduleSeats_InvalidEventScheduleId_ThrowsException() {
+        BusinessException exception = assertThrows(BusinessException.class, 
+            () -> bookingSeatService.getEventScheduleSeats(null));
+        
+        assertEquals(EventErrorCodes.EVENT_ID_REQUIRED, exception.getErrorCode());
+    }
 
-    List<SeatMapDetail> result = bookingSeatService.getSeatMapOnlyByGrade(scheduleId, seatGrade);
+    @Test
+    @DisplayName("존재하지 않는 이벤트 스케줄로 좌석 정보 조회 시 예외 발생")
+    void getEventScheduleSeats_NonExistentEventSchedule_ThrowsException() {
+        when(eventScheduleRepository.findById(validEventScheduleId))
+            .thenReturn(Optional.empty());
 
-    assertEquals(2, result.size());
+        BusinessException exception = assertThrows(BusinessException.class, 
+            () -> bookingSeatService.getEventScheduleSeats(validEventScheduleId));
+        
+        assertEquals(EventErrorCodes.SCHEDULE_NOT_FOUND, exception.getErrorCode());
+    }
 
-    assertTrue(result.stream().anyMatch(seat -> seat.getSeatId().equals(1L) && seat.isBooked()));
-    assertTrue(result.stream().anyMatch(seat -> seat.getSeatId().equals(2L) && !seat.isBooked()));
-  }
+    @Test
+    @DisplayName("좌석이 없는 장소로 좌석 정보 조회 시 예외 발생")
+    void getEventScheduleSeats_NoSeatsInVenue_ThrowsException() {
+        when(eventScheduleRepository.findById(validEventScheduleId))
+            .thenReturn(Optional.of(validEventSchedule));
+        when(seatRepository.findByVenueId(validVenueId))
+            .thenReturn(Collections.emptyList());
 
-  @Test
-  void 좌석등급별_남은좌석_수_정상조회() {
-    Long scheduleId = 1L;
-    Long venueId = 300L;
+        BusinessException exception = assertThrows(BusinessException.class, 
+            () -> bookingSeatService.getEventScheduleSeats(validEventScheduleId));
+        
+        assertEquals(EventErrorCodes.SEAT_NOT_FOUND, exception.getErrorCode());
+    }
 
-    EventSchedule eventSchedule =
-        EventSchedule.builder().eventScheduleId(scheduleId).venueId(venueId).build();
+    @Test
+    @DisplayName("정상적인 좌석 맵 조회 테스트")
+    void getSeatMapOnlyByGrade_Success() {
+        List<Seat> seats = Arrays.asList(validSeat);
+        List<SeatClass> seatClasses = Arrays.asList(createSeatClass(1L, "VIP"));
+        
+        when(eventScheduleRepository.findById(validEventScheduleId))
+            .thenReturn(Optional.of(validEventSchedule));
+        when(seatRepository.findByVenueId(validVenueId))
+            .thenReturn(seats);
+        when(bookingRepository.findByEventScheduleIdAndStatus(validEventScheduleId, Booking.Booked.BOOKED))
+            .thenReturn(Collections.emptyList());
+        when(bookingRepository.findByEventScheduleIdAndStatus(validEventScheduleId, Booking.Booked.PENDING))
+            .thenReturn(Collections.emptyList());
+        when(seatClassRepository.findAll())
+            .thenReturn(seatClasses);
 
-    SeatClass vip = new SeatClass(10L, "VIP", null, null, null);
-    SeatClass r = new SeatClass(20L, "R", null, null, null);
+        List<SeatMapDetail> result = bookingSeatService.getSeatMapOnlyByGrade(validEventScheduleId, "VIP");
 
-    Seat seat1 = new Seat(1L, venueId, 10L, 1L, "A", "1", null, null);
-    Seat seat2 = new Seat(2L, venueId, 10L, 1L, "A", "2", null, null);
-    Seat seat3 = new Seat(3L, venueId, 20L, 1L, "B", "1", null, null);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(validSeatId, result.get(0).getSeatId());
+        assertEquals("A", result.get(0).getRow());
+        assertEquals(1, result.get(0).getCol());
+        assertEquals("VIP", result.get(0).getSeatGrade());
+        assertFalse(result.get(0).isBooked());
+    }
 
-    Booking booked = Booking.builder().seatId(1L).eventScheduleId(scheduleId)
-        .status(Booking.Booked.BOOKED).build();
+    @Test
+    @DisplayName("유효하지 않은 이벤트 스케줄 ID로 좌석 맵 조회 시 예외 발생")
+    void getSeatMapOnlyByGrade_InvalidEventScheduleId_ThrowsException() {
+        BusinessException exception = assertThrows(BusinessException.class, 
+            () -> bookingSeatService.getSeatMapOnlyByGrade(null, "VIP"));
+        
+        assertEquals(EventErrorCodes.EVENT_ID_REQUIRED, exception.getErrorCode());
+    }
 
-    Price vipPrice =
-        Price.builder().eventScheduleId(scheduleId).seatClassId(10L).price(198000).build();
+    @Test
+    @DisplayName("빈 좌석 등급으로 좌석 맵 조회 시 예외 발생")
+    void getSeatMapOnlyByGrade_EmptySeatGrade_ThrowsException() {
+        BusinessException exception = assertThrows(BusinessException.class, 
+            () -> bookingSeatService.getSeatMapOnlyByGrade(validEventScheduleId, ""));
+        
+        assertEquals(EventErrorCodes.SEAT_CLASS_NOT_FOUND, exception.getErrorCode());
+    }
 
-    Price rPrice =
-        Price.builder().eventScheduleId(scheduleId).seatClassId(20L).price(178000).build();
+    @Test
+    @DisplayName("존재하지 않는 좌석 등급으로 좌석 맵 조회 시 예외 발생")
+    void getSeatMapOnlyByGrade_NonExistentSeatGrade_ThrowsException() {
+        List<Seat> seats = Arrays.asList(validSeat);
+        List<SeatClass> seatClasses = Arrays.asList(createSeatClass(1L, "VIP"));
+        
+        when(eventScheduleRepository.findById(validEventScheduleId))
+            .thenReturn(Optional.of(validEventSchedule));
+        when(seatRepository.findByVenueId(validVenueId))
+            .thenReturn(seats);
+        when(bookingRepository.findByEventScheduleIdAndStatus(validEventScheduleId, Booking.Booked.BOOKED))
+            .thenReturn(Collections.emptyList());
+        when(bookingRepository.findByEventScheduleIdAndStatus(validEventScheduleId, Booking.Booked.PENDING))
+            .thenReturn(Collections.emptyList());
+        when(seatClassRepository.findAll())
+            .thenReturn(seatClasses);
 
-    when(eventScheduleRepository.findById(scheduleId)).thenReturn(Optional.of(eventSchedule));
-    when(seatRepository.findByVenueId(venueId)).thenReturn(List.of(seat1, seat2, seat3));
-    when(seatClassRepository.findAll()).thenReturn(List.of(vip, r));
-    when(
-        bookingRepository.findByEventScheduleIdAndStatus(eq(scheduleId), eq(Booking.Booked.BOOKED)))
-        .thenReturn(List.of(booked));
-    when(priceRepository.findByEventScheduleId(scheduleId)).thenReturn(List.of(vipPrice, rPrice));
-    when(seatRepository.findById(1L)).thenReturn(Optional.of(seat1));
+        BusinessException exception = assertThrows(BusinessException.class, 
+            () -> bookingSeatService.getSeatMapOnlyByGrade(validEventScheduleId, "NON_EXISTENT"));
+        
+        assertEquals(EventErrorCodes.SEAT_CLASS_NOT_FOUND, exception.getErrorCode());
+    }
 
-    var result = bookingSeatService.getEventScheduleSeats(scheduleId);
+    @Test
+    @DisplayName("PENDING 예약 삭제 테스트")
+    void deletePendingBookings_Success() {
+        List<Booking> pendingBookings = Arrays.asList(validBooking);
+        when(bookingRepository.findByStatus(Booking.Booked.PENDING))
+            .thenReturn(pendingBookings);
 
-    assertEquals(scheduleId, result.getEventScheduleId());
-    assertEquals(2, result.getRemainingSeatsByGrade().size());
+        bookingSeatService.deletePendingBookings();
 
-    var vipResult = result.getRemainingSeatsByGrade().stream()
-        .filter(rg -> rg.getSeatGrade().equals("VIP")).findFirst().orElseThrow();
+        verify(bookingRepository).findByStatus(Booking.Booked.PENDING);
+        verify(bookingRepository).delete(validBooking);
+    }
 
-    assertEquals(1, vipResult.getRemainingSeats());
-    assertEquals(198000, vipResult.getPrice());
+    @Test
+    @DisplayName("삭제할 PENDING 예약이 없는 경우")
+    void deletePendingBookings_NoPendingBookings() {
+        when(bookingRepository.findByStatus(Booking.Booked.PENDING))
+            .thenReturn(Collections.emptyList());
 
-    var rResult = result.getRemainingSeatsByGrade().stream()
-        .filter(rg -> rg.getSeatGrade().equals("R")).findFirst().orElseThrow();
+        bookingSeatService.deletePendingBookings();
 
-    assertEquals(1, rResult.getRemainingSeats());
-    assertEquals(178000, rResult.getPrice());
-  }
+        verify(bookingRepository).findByStatus(Booking.Booked.PENDING);
+        verify(bookingRepository, never()).delete(any(Booking.class));
+    }
 
+    @Test
+    @DisplayName("PENDING 예약 삭제 중 예외 발생 시 로그 기록")
+    void deletePendingBookings_ExceptionDuringDeletion_LogsError() {
+        List<Booking> pendingBookings = Arrays.asList(validBooking);
+        when(bookingRepository.findByStatus(Booking.Booked.PENDING))
+            .thenReturn(pendingBookings);
+        doThrow(new RuntimeException("Database error"))
+            .when(bookingRepository).delete(validBooking);
+
+        bookingSeatService.deletePendingBookings();
+
+        verify(bookingRepository).findByStatus(Booking.Booked.PENDING);
+        verify(bookingRepository).delete(validBooking);
+    }
+
+    private SeatClass createSeatClass(Long seatClassId, String className) {
+        SeatClass seatClass = new SeatClass();
+        seatClass.setSeatClassId(seatClassId);
+        seatClass.setClassName(className);
+        return seatClass;
+    }
+
+    private Price createPrice(Long seatClassId, Integer price) {
+        Price priceObj = new Price();
+        priceObj.setSeatClassId(seatClassId);
+        priceObj.setPrice(price);
+        return priceObj;
+    }
 }


### PR DESCRIPTION
## ✏️ 작업 개요  
좌석 선택 후 결제버튼 누르면 booking 테이블 추가되는 api

## 🔨 작업 내용 상세
- 입력 데이터 검증 (이벤트 스케줄 ID, 좌석 ID, 계정 ID)
- 이벤트 스케줄 및 좌석 존재 여부 확인
- 좌석 중복 예약 방지 (BOOKED, PENDING 상태 체크)
- 사용자별 이벤트 중복 예약 방지
- 초기 예약 상태: payment_id는 null, 상태는 PENDING으로 생성 / kafka 미구현 -> 기능 확정 후 구현 예정
  - 결제 완료 후 kafka sub 
  - 상태 업데이트 후 kakfka pub
- PENDING 예약 자동 삭제: 5분마다 실행되는 스케줄러 생성
- 단위 테스트:
  - 정상 케이스: 성공적인 예약 생성, 좌석 조회
  - 예외 케이스:
    - 잘못된 입력 데이터
    - 존재하지 않는 리소스
    - 중복 예약 시도
    - 스케줄러 오류 처리

## 🔗 관련 이슈  
- Closes #47 

## ✅ 체크리스트  
- [x] entity 수정: status -> PENDING 추가 / userId -> accountId 변경
- [x] DTO: `BookingRequestDt`, `BookingResponseDto`
- [x] Controller: POST `/booking` 
- [x] Service - `createBooking`
- [x] 스케줄러: PENDING 상태 5분단위로 삭제
- [x] 서비스 단위테스트: `BookingSeatServiceTest`
- [x] postman collection 추가

## 💬 기타 참고 사항  
- 엔티티 수정했기때문에 DB 다시 생성해야함!! insert문 없는 사람 슬랙으로 연락바람~~
- API postman test 방법
  - POST -> `http://localhost:8081/event/api/events/booking`
  - Header -> X-Auth-AccountId: 1 / X-Auth-Role: USER / Content-Type: application/json
  - Body ->{ "eventScheduleId": 1, "seatId": 97 }
