### PR TITLE
Feat/pyokemon 76 공연 정보 수정

### DIFF
--- a/account/src/main/java/com/pyokemon/account/AccountApplication.java
+++ b/account/src/main/java/com/pyokemon/account/AccountApplication.java
@@ -6,11 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
-@ComponentScan(basePackages = {
-    "com.pyokemon.account", 
-    "com.pyokemon.common",
-    "com.pyokemon.common.exception"
-})
+@ComponentScan(
+    basePackages = {"com.pyokemon.account", "com.pyokemon.common", "com.pyokemon.common.exception"})
 @MapperScan({"com.pyokemon.account.auth.repository", "com.pyokemon.account.tenant.repository",
     "com.pyokemon.account.user.repository", "com.pyokemon.account.admin.repository"})
 public class AccountApplication {

--- a/account/src/main/java/com/pyokemon/account/auth/constants/AuthConstants.java
+++ b/account/src/main/java/com/pyokemon/account/auth/constants/AuthConstants.java
@@ -4,6 +4,6 @@ package com.pyokemon.account.auth.constants;
  * 인증 관련 상수 정의 클래스
  */
 public class AuthConstants {
-    public static final String BLACKLIST_PREFIX = "blacklist:";
-    public static final String BEARER_PREFIX = "Bearer ";
+  public static final String BLACKLIST_PREFIX = "blacklist:";
+  public static final String BEARER_PREFIX = "Bearer ";
 }

--- a/account/src/main/java/com/pyokemon/account/auth/secret/jwt/JwtAuthenticationFilter.java
+++ b/account/src/main/java/com/pyokemon/account/auth/secret/jwt/JwtAuthenticationFilter.java
@@ -9,11 +9,11 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import lombok.extern.slf4j.Slf4j;
@@ -52,7 +52,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
           new UsernamePasswordAuthenticationToken(accountId, null, authorities);
 
       SecurityContextHolder.getContext().setAuthentication(authentication);
-      
+
     } catch (AuthenticationException e) {
       // Spring Security 예외는 그대로 던져서 AuthenticationEntryPoint에서 처리
       throw e;
@@ -67,7 +67,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private boolean isPublicApi(String requestURI) {
     String actualPath = requestURI.replace("/account", "");
-    return actualPath.equals("/api/login") || actualPath.equals("/api/users") || actualPath.equals("/api/tenants");
+    return actualPath.equals("/api/login") || actualPath.equals("/api/users")
+        || actualPath.equals("/api/tenants");
   }
 
   private String extractAccountId(HttpServletRequest request) {

--- a/account/src/main/java/com/pyokemon/account/auth/service/AccountService.java
+++ b/account/src/main/java/com/pyokemon/account/auth/service/AccountService.java
@@ -1,14 +1,15 @@
 package com.pyokemon.account.auth.service;
 
 import java.util.Date;
-import java.util.concurrent.TimeUnit;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.pyokemon.account.auth.constants.AuthConstants;
 import com.pyokemon.account.auth.dto.request.LoginRequestDto;
 import com.pyokemon.account.auth.dto.request.UpdatePasswordRequestDto;
 import com.pyokemon.account.auth.dto.response.LoginResponseDto;
@@ -17,7 +18,6 @@ import com.pyokemon.account.auth.entity.Account;
 import com.pyokemon.account.auth.entity.AccountStatus;
 import com.pyokemon.account.auth.repository.AccountRepository;
 import com.pyokemon.account.auth.secret.jwt.TokenGenerator;
-import com.pyokemon.account.auth.constants.AuthConstants;
 import com.pyokemon.common.exception.BusinessException;
 import com.pyokemon.common.exception.code.AccountErrorCodes;
 
@@ -38,9 +38,10 @@ public class AccountService {
   @Transactional
   public LoginResponseDto login(LoginRequestDto request) {
     log.info("로그인 시도: {}", request.getLoginId());
-    
+
     // 계정 조회
-    Optional<Account> accountOpt = accountRepository.findByLoginIdAndStatus(request.getLoginId(), AccountStatus.ACTIVE);
+    Optional<Account> accountOpt =
+        accountRepository.findByLoginIdAndStatus(request.getLoginId(), AccountStatus.ACTIVE);
     if (accountOpt.isEmpty()) {
       log.warn("로그인 실패: 계정을 찾을 수 없음 - {}", request.getLoginId());
       throw new BusinessException("계정을 찾을 수 없습니다.", AccountErrorCodes.ACCOUNT_NOT_FOUND);
@@ -59,68 +60,61 @@ public class AccountService {
         tokenGenerator.generateAccessToken(account.getAccountId(), account.getRole());
     String refreshToken =
         tokenGenerator.generateRefreshToken(account.getAccountId(), account.getRole());
-    
+
     log.info("로그인 성공: {} (역할: {})", request.getLoginId(), account.getRole());
 
-    return LoginResponseDto.builder()
-        .accessToken(accessToken)
-        .refreshToken(refreshToken)
-        .role(account.getRole())
-        .accountId(account.getAccountId())
-        .build();
+    return LoginResponseDto.builder().accessToken(accessToken).refreshToken(refreshToken)
+        .role(account.getRole()).accountId(account.getAccountId()).build();
   }
 
   @Transactional
   public TokenResponseDto refreshToken(String refreshToken) {
     log.info("토큰 갱신 시도");
-    
+
     // 1. 리프레시 토큰 유효성 검증
     if (!tokenGenerator.validateToken(refreshToken)) {
       log.warn("토큰 갱신 실패: 유효하지 않은 토큰");
       throw new BusinessException("유효하지 않은 리프레시 토큰입니다.", AccountErrorCodes.INVALID_TOKEN);
     }
-    
+
     // 2. 블랙리스트 확인
     if (Boolean.TRUE.equals(redisTemplate.hasKey(AuthConstants.BLACKLIST_PREFIX + refreshToken))) {
       log.warn("토큰 갱신 실패: 블랙리스트에 등록된 토큰");
       throw new BusinessException("로그아웃된 토큰입니다.", AccountErrorCodes.INVALID_TOKEN);
     }
-    
+
     try {
       // 3. 토큰에서 사용자 정보 추출
       Claims claims = tokenGenerator.parseToken(refreshToken);
       String accountIdStr = claims.getSubject();
       String role = claims.get("role", String.class);
-      
+
       if (accountIdStr == null || role == null) {
         log.warn("토큰 갱신 실패: 토큰에서 사용자 정보를 추출할 수 없음");
         throw new BusinessException("토큰에서 사용자 정보를 추출할 수 없습니다.", AccountErrorCodes.INVALID_TOKEN);
       }
-      
+
       Long accountId = Long.parseLong(accountIdStr);
-      
+
       // 4. 계정 존재 확인
-      Account account = accountRepository.findByAccountId(accountId)
-          .orElseThrow(() -> {
-            log.warn("토큰 갱신 실패: 계정을 찾을 수 없음 - ID: {}", accountId);
-            return new BusinessException("계정을 찾을 수 없습니다.", AccountErrorCodes.ACCOUNT_NOT_FOUND);
-          });
-      
+      Account account = accountRepository.findByAccountId(accountId).orElseThrow(() -> {
+        log.warn("토큰 갱신 실패: 계정을 찾을 수 없음 - ID: {}", accountId);
+        return new BusinessException("계정을 찾을 수 없습니다.", AccountErrorCodes.ACCOUNT_NOT_FOUND);
+      });
+
       // 5. 계정 상태 확인
       if (account.getStatus() == AccountStatus.DELETED) {
         log.warn("토큰 갱신 실패: 삭제된 계정 - ID: {}", accountId);
         throw new BusinessException("삭제된 계정입니다.", AccountErrorCodes.ACCOUNT_DELETED);
       }
-      
+
       // 6. 새 액세스 토큰 생성
       String newAccessToken = tokenGenerator.generateAccessToken(accountId, role);
-      
+
       log.info("토큰 갱신 성공: 계정 ID: {}, 역할: {}", accountId, role);
-      
+
       // 7. 응답 데이터 구성
-      return TokenResponseDto.builder()
-          .accessToken(newAccessToken)
-          .build();
+      return TokenResponseDto.builder().accessToken(newAccessToken).build();
     } catch (BusinessException e) {
       throw e;
     } catch (Exception e) {
@@ -132,24 +126,23 @@ public class AccountService {
   @Transactional
   public void changePassword(Long accountId, UpdatePasswordRequestDto request) {
     log.info("비밀번호 변경 시도: 계정 ID: {}", accountId);
-    
+
     // 1. 계정 조회
-    Account account = accountRepository.findByAccountId(accountId)
-        .orElseThrow(() -> {
-          log.warn("비밀번호 변경 실패: 계정을 찾을 수 없음 - ID: {}", accountId);
-          return new BusinessException("계정을 찾을 수 없습니다.", AccountErrorCodes.ACCOUNT_NOT_FOUND);
-        });
+    Account account = accountRepository.findByAccountId(accountId).orElseThrow(() -> {
+      log.warn("비밀번호 변경 실패: 계정을 찾을 수 없음 - ID: {}", accountId);
+      return new BusinessException("계정을 찾을 수 없습니다.", AccountErrorCodes.ACCOUNT_NOT_FOUND);
+    });
 
     // 2. 현재 비밀번호 확인
     if (!passwordEncoder.matches(request.getCurrentPassword(), account.getPassword())) {
-        log.warn("비밀번호 변경 실패: 현재 비밀번호 불일치 - ID: {}", accountId);
-        throw new BusinessException("현재 비밀번호가 일치하지 않습니다.", AccountErrorCodes.PASSWORD_MISMATCH);
+      log.warn("비밀번호 변경 실패: 현재 비밀번호 불일치 - ID: {}", accountId);
+      throw new BusinessException("현재 비밀번호가 일치하지 않습니다.", AccountErrorCodes.PASSWORD_MISMATCH);
     }
 
     // 3. 새 비밀번호가 현재 비밀번호와 같은지 확인
     if (passwordEncoder.matches(request.getNewPassword(), account.getPassword())) {
-        log.warn("비밀번호 변경 실패: 새 비밀번호가 현재 비밀번호와 동일함 - ID: {}", accountId);
-        throw new BusinessException("새 비밀번호는 현재 비밀번호와 달라야 합니다.", AccountErrorCodes.PASSWORD_MATCH);
+      log.warn("비밀번호 변경 실패: 새 비밀번호가 현재 비밀번호와 동일함 - ID: {}", accountId);
+      throw new BusinessException("새 비밀번호는 현재 비밀번호와 달라야 합니다.", AccountErrorCodes.PASSWORD_MATCH);
     }
 
     // 4. 새 비밀번호 암호화 및 저장
@@ -164,32 +157,28 @@ public class AccountService {
   @Transactional
   public void logout(String token) {
     log.info("로그아웃 시도");
-    
+
     // 토큰이 null인 경우 처리
     if (token == null) {
       log.warn("로그아웃 실패: 토큰이 없음");
       return;
     }
-    
+
     // 토큰에서 "Bearer " 접두사 제거
     if (token.startsWith(AuthConstants.BEARER_PREFIX)) {
       token = token.substring(AuthConstants.BEARER_PREFIX.length());
     }
-    
+
     // Redis에 토큰 블랙리스트 추가
     try {
       Claims claims = tokenGenerator.parseToken(token);
       Date expiration = claims.getExpiration();
       long ttl = (expiration.getTime() - System.currentTimeMillis()) / 1000;
-      
+
       if (ttl > 0) {
         // Redis에 블랙리스트 추가 (토큰을 키로, 값은 "blacklisted"로 설정)
-        redisTemplate.opsForValue().set(
-            AuthConstants.BLACKLIST_PREFIX + token, 
-            "blacklisted", 
-            ttl, 
-            TimeUnit.SECONDS
-        );
+        redisTemplate.opsForValue().set(AuthConstants.BLACKLIST_PREFIX + token, "blacklisted", ttl,
+            TimeUnit.SECONDS);
         log.info("로그아웃 성공: 토큰이 블랙리스트에 추가됨 (만료 시간: {}초)", ttl);
       } else {
         log.info("로그아웃: 이미 만료된 토큰");
@@ -203,14 +192,14 @@ public class AccountService {
   @Transactional
   public void deleteAccount(Long accountId) {
     log.info("계정 삭제 시도: ID: {}", accountId);
-    
+
     // 계정 존재 확인
     boolean exists = accountRepository.findByAccountId(accountId).isPresent();
     if (!exists) {
       log.warn("계정 삭제 실패: 계정을 찾을 수 없음 - ID: {}", accountId);
       throw new BusinessException("계정을 찾을 수 없습니다.", AccountErrorCodes.ACCOUNT_NOT_FOUND);
     }
-    
+
     // 계정 상태를 DELETED로 변경
     accountRepository.updateStatus(accountId, AccountStatus.DELETED);
     log.info("계정 삭제 성공: ID: {}", accountId);

--- a/account/src/main/java/com/pyokemon/account/common/config/RedisConfig.java
+++ b/account/src/main/java/com/pyokemon/account/common/config/RedisConfig.java
@@ -9,12 +9,12 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
 
-    @Bean
-    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, String> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-        template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new StringRedisSerializer());
-        return template;
-    }
-} 
+  @Bean
+  public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, String> template = new RedisTemplate<>();
+    template.setConnectionFactory(connectionFactory);
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new StringRedisSerializer());
+    return template;
+  }
+}

--- a/account/src/main/java/com/pyokemon/account/common/config/SecurityConfig.java
+++ b/account/src/main/java/com/pyokemon/account/common/config/SecurityConfig.java
@@ -1,27 +1,28 @@
 package com.pyokemon.account.common.config;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.AuthenticationEntryPoint;
-import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pyokemon.account.auth.secret.jwt.JwtAuthenticationFilter;
 import com.pyokemon.common.dto.ResponseDto;
 import com.pyokemon.common.exception.code.AccountErrorCodes;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -49,8 +50,7 @@ public class SecurityConfig {
             .requestMatchers("/api/users/**").hasRole("USER")
             // 기타 모든 요청은 인증 필요
             .anyRequest().authenticated())
-        .addFilterBefore(new JwtAuthenticationFilter(),
-            UsernamePasswordAuthenticationFilter.class)
+        .addFilterBefore(new JwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
         .exceptionHandling(exceptionHandling -> exceptionHandling
             .authenticationEntryPoint(customAuthenticationEntryPoint())
             .accessDeniedHandler(customAccessDeniedHandler()));
@@ -65,7 +65,8 @@ public class SecurityConfig {
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
       response.setCharacterEncoding("UTF-8");
 
-      ResponseDto<Void> errorResponse = ResponseDto.error("인증이 필요합니다.", AccountErrorCodes.ACCESS_DENIED);
+      ResponseDto<Void> errorResponse =
+          ResponseDto.error("인증이 필요합니다.", AccountErrorCodes.ACCESS_DENIED);
       String jsonResponse = objectMapper.writeValueAsString(errorResponse);
       response.getWriter().write(jsonResponse);
     };
@@ -78,7 +79,8 @@ public class SecurityConfig {
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
       response.setCharacterEncoding("UTF-8");
 
-      ResponseDto<Void> errorResponse = ResponseDto.error("접근 권한이 없습니다.", AccountErrorCodes.PERMISSION_DENIED);
+      ResponseDto<Void> errorResponse =
+          ResponseDto.error("접근 권한이 없습니다.", AccountErrorCodes.PERMISSION_DENIED);
       String jsonResponse = objectMapper.writeValueAsString(errorResponse);
       response.getWriter().write(jsonResponse);
     };

--- a/account/src/main/java/com/pyokemon/account/user/controller/UserController.java
+++ b/account/src/main/java/com/pyokemon/account/user/controller/UserController.java
@@ -1,15 +1,15 @@
 package com.pyokemon.account.user.controller;
 
-import com.pyokemon.account.common.web.context.GatewayRequestHeaderUtils;
 import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import com.pyokemon.account.user.dto.request.UpdateUserRequestDto;
-import com.pyokemon.account.user.dto.request.RegisterDeviceRequestDto;
+import com.pyokemon.account.common.web.context.GatewayRequestHeaderUtils;
 import com.pyokemon.account.user.dto.request.CreateUserRequestDto;
+import com.pyokemon.account.user.dto.request.RegisterDeviceRequestDto;
+import com.pyokemon.account.user.dto.request.UpdateUserRequestDto;
 import com.pyokemon.account.user.dto.response.UserDetailDto;
 import com.pyokemon.account.user.service.UserService;
 import com.pyokemon.common.dto.ResponseDto;
@@ -21,65 +21,61 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserController {
 
-    private final UserService userService;
+  private final UserService userService;
 
-    // 사용자 계정 생성
-    @PostMapping
-    public ResponseEntity<ResponseDto<UserDetailDto>> registerUser(
-            @Valid @RequestBody CreateUserRequestDto request) {
-        UserDetailDto response = userService.registerUser(request);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ResponseDto.success(response, "사용자 등록 성공"));
-    }
+  // 사용자 계정 생성
+  @PostMapping
+  public ResponseEntity<ResponseDto<UserDetailDto>> registerUser(
+      @Valid @RequestBody CreateUserRequestDto request) {
+    UserDetailDto response = userService.registerUser(request);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ResponseDto.success(response, "사용자 등록 성공"));
+  }
 
-    // 사용자 계정 상세 조회 (사용자 본인만)
-    @GetMapping("/profile")
-    public ResponseEntity<ResponseDto<UserDetailDto>> getUserProfile() {
-        String currentUserAccountId = GatewayRequestHeaderUtils.getUserIdOrThrowException();
-        Long userId = Long.parseLong(currentUserAccountId);
-        UserDetailDto response = userService.getUserProfile(userId);
-        return ResponseEntity.ok(ResponseDto.success(response, "사용자 정보 조회 성공"));
-    }
+  // 사용자 계정 상세 조회 (사용자 본인만)
+  @GetMapping("/profile")
+  public ResponseEntity<ResponseDto<UserDetailDto>> getUserProfile() {
+    String currentUserAccountId = GatewayRequestHeaderUtils.getUserIdOrThrowException();
+    Long userId = Long.parseLong(currentUserAccountId);
+    UserDetailDto response = userService.getUserProfile(userId);
+    return ResponseEntity.ok(ResponseDto.success(response, "사용자 정보 조회 성공"));
+  }
 
-    // 사용자 정보 수정 (사용자 본인만)
-    @PutMapping("/profile")
-    public ResponseEntity<ResponseDto<UserDetailDto>> updateUserProfile(
-            @Valid @RequestBody UpdateUserRequestDto request
-            ) {
-        String currentUserAccountId = GatewayRequestHeaderUtils.getUserIdOrThrowException();
-        Long userId = Long.parseLong(currentUserAccountId);
-        UserDetailDto response = userService.updateUserProfile(userId, request);
-        return ResponseEntity.ok(ResponseDto.success(response, "사용자 정보 수정 성공"));
-    }
+  // 사용자 정보 수정 (사용자 본인만)
+  @PutMapping("/profile")
+  public ResponseEntity<ResponseDto<UserDetailDto>> updateUserProfile(
+      @Valid @RequestBody UpdateUserRequestDto request) {
+    String currentUserAccountId = GatewayRequestHeaderUtils.getUserIdOrThrowException();
+    Long userId = Long.parseLong(currentUserAccountId);
+    UserDetailDto response = userService.updateUserProfile(userId, request);
+    return ResponseEntity.ok(ResponseDto.success(response, "사용자 정보 수정 성공"));
+  }
 
-    // 사용자 계정 삭제 (탈퇴) (사용자 본인만)
-    @DeleteMapping("/profile")
-    public ResponseEntity<ResponseDto<Void>> deleteUser() {
-        String currentUserAccountId = GatewayRequestHeaderUtils.getUserIdOrThrowException();
-        Long userId = Long.parseLong(currentUserAccountId);
-        userService.deleteUser(userId);
-        return ResponseEntity.ok(ResponseDto.success("사용자 탈퇴 성공"));
-    }
+  // 사용자 계정 삭제 (탈퇴) (사용자 본인만)
+  @DeleteMapping("/profile")
+  public ResponseEntity<ResponseDto<Void>> deleteUser() {
+    String currentUserAccountId = GatewayRequestHeaderUtils.getUserIdOrThrowException();
+    Long userId = Long.parseLong(currentUserAccountId);
+    userService.deleteUser(userId);
+    return ResponseEntity.ok(ResponseDto.success("사용자 탈퇴 성공"));
+  }
 
-    // 사용자 기기 등록 (사용자 본인만)
-    @PostMapping("/devices")
-    public ResponseEntity<ResponseDto<Void>> registerUserDevice(
-            @Valid @RequestBody RegisterDeviceRequestDto request
-            ) {
-        String currentUserAccountId = GatewayRequestHeaderUtils.getUserIdOrThrowException();
-        Long userId = Long.parseLong(currentUserAccountId);
-        userService.registerUserDevice(userId, request);
-        return ResponseEntity.ok(ResponseDto.success("기기 등록 성공"));
-    }
+  // 사용자 기기 등록 (사용자 본인만)
+  @PostMapping("/devices")
+  public ResponseEntity<ResponseDto<Void>> registerUserDevice(
+      @Valid @RequestBody RegisterDeviceRequestDto request) {
+    String currentUserAccountId = GatewayRequestHeaderUtils.getUserIdOrThrowException();
+    Long userId = Long.parseLong(currentUserAccountId);
+    userService.registerUserDevice(userId, request);
+    return ResponseEntity.ok(ResponseDto.success("기기 등록 성공"));
+  }
 
-    // 사용자 기기 삭제 (사용자 본인만)
-    @DeleteMapping("/devices/{deviceId}")
-    public ResponseEntity<ResponseDto<Void>> deleteUserDevice(
-            @PathVariable String deviceId
-            ) {
-        String currentUserAccountId = GatewayRequestHeaderUtils.getUserIdOrThrowException();
-        Long userId = Long.parseLong(currentUserAccountId);
-        userService.deleteUserDevice(userId, deviceId);
-        return ResponseEntity.ok(ResponseDto.success("기기 삭제 성공"));
-    }
+  // 사용자 기기 삭제 (사용자 본인만)
+  @DeleteMapping("/devices/{deviceId}")
+  public ResponseEntity<ResponseDto<Void>> deleteUserDevice(@PathVariable String deviceId) {
+    String currentUserAccountId = GatewayRequestHeaderUtils.getUserIdOrThrowException();
+    Long userId = Long.parseLong(currentUserAccountId);
+    userService.deleteUserDevice(userId, deviceId);
+    return ResponseEntity.ok(ResponseDto.success("기기 삭제 성공"));
+  }
 }

--- a/account/src/main/java/com/pyokemon/account/user/dto/request/CreateUserRequestDto.java
+++ b/account/src/main/java/com/pyokemon/account/user/dto/request/CreateUserRequestDto.java
@@ -17,31 +17,24 @@ import lombok.Setter;
 @AllArgsConstructor
 public class CreateUserRequestDto {
 
-    @NotBlank(message = "로그인 ID는 필수입니다.")
-    @Size(min = 4, max = 20, message = "로그인 ID는 4~20자여야 합니다.")
-    private String loginId;
+  @NotBlank(message = "로그인 ID는 필수입니다.")
+  @Size(min = 4, max = 20, message = "로그인 ID는 4~20자여야 합니다.")
+  private String loginId;
 
-    @NotBlank(message = "비밀번호는 필수입니다.")
-    @Pattern(
-            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
-            message = "비밀번호는 8자 이상이며, 영문, 숫자, 특수문자를 포함해야 합니다.")
-    private String password;
+  @NotBlank(message = "비밀번호는 필수입니다.")
+  @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
+      message = "비밀번호는 8자 이상이며, 영문, 숫자, 특수문자를 포함해야 합니다.")
+  private String password;
 
-    @NotBlank(message = "이름은 필수입니다.")
-    @Pattern(
-            regexp = "^[가-힣a-zA-Z0-9]+$",
-            message = "이름은 한글, 영문, 숫자만 포함할 수 있습니다."
-    )
-    private String name;
+  @NotBlank(message = "이름은 필수입니다.")
+  @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "이름은 한글, 영문, 숫자만 포함할 수 있습니다.")
+  private String name;
 
-    @NotBlank(message = "전화번호는 필수입니다.")
-    @Pattern(
-            regexp = "^\\d{3}-\\d{3,4}-\\d{4}$",
-            message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)"
-    )
-    private String phone;
+  @NotBlank(message = "전화번호는 필수입니다.")
+  @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)")
+  private String phone;
 
-    @NotNull(message = "생년월일은 필수입니다.")
-    @Past(message = "생년월일은 과거 날짜여야 합니다.")
-    private LocalDate birth;
+  @NotNull(message = "생년월일은 필수입니다.")
+  @Past(message = "생년월일은 과거 날짜여야 합니다.")
+  private LocalDate birth;
 }

--- a/account/src/main/java/com/pyokemon/account/user/dto/request/RegisterDeviceRequestDto.java
+++ b/account/src/main/java/com/pyokemon/account/user/dto/request/RegisterDeviceRequestDto.java
@@ -1,8 +1,8 @@
 package com.pyokemon.account.user.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-
 import jakarta.validation.constraints.Pattern;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,24 +16,15 @@ import lombok.Setter;
 @AllArgsConstructor
 public class RegisterDeviceRequestDto {
 
-    @NotBlank(message = "디바이스 ID는 필수입니다.")
-    @Pattern(
-            regexp = "^[a-zA-Z0-9_-]+$",
-            message = "디바이스 ID는 영문자, 숫자, 하이픈(-) 또는 언더바(_)만 포함할 수 있습니다."
-    )
-    private String deviceNumber;
+  @NotBlank(message = "디바이스 ID는 필수입니다.")
+  @Pattern(regexp = "^[a-zA-Z0-9_-]+$", message = "디바이스 ID는 영문자, 숫자, 하이픈(-) 또는 언더바(_)만 포함할 수 있습니다.")
+  private String deviceNumber;
 
-    @NotBlank(message = "FCM 토큰은 필수입니다.")
-    @Pattern(
-            regexp = "^[a-zA-Z0-9_-]+$",
-            message = "FCM 토큰은 영문자, 숫자, 하이픈(-) 또는 언더바(_)만 포함할 수 있습니다."
-    )
-    private String fcmToken;
+  @NotBlank(message = "FCM 토큰은 필수입니다.")
+  @Pattern(regexp = "^[a-zA-Z0-9_-]+$", message = "FCM 토큰은 영문자, 숫자, 하이픈(-) 또는 언더바(_)만 포함할 수 있습니다.")
+  private String fcmToken;
 
-    @NotBlank(message = "운영체제 타입은 필수입니다.")
-    @Pattern(
-            regexp = "^(ANDROID|IOS)$",
-            message = "운영체제 타입은 ANDROID 또는 IOS 중 하나여야 합니다."
-    )
-    private String osType; // ANDROID, IOS
+  @NotBlank(message = "운영체제 타입은 필수입니다.")
+  @Pattern(regexp = "^(ANDROID|IOS)$", message = "운영체제 타입은 ANDROID 또는 IOS 중 하나여야 합니다.")
+  private String osType; // ANDROID, IOS
 }

--- a/account/src/main/java/com/pyokemon/account/user/dto/request/UpdateUserRequestDto.java
+++ b/account/src/main/java/com/pyokemon/account/user/dto/request/UpdateUserRequestDto.java
@@ -20,17 +20,14 @@ import lombok.Setter;
 @AllArgsConstructor
 public class UpdateUserRequestDto {
 
-    @NotBlank(message = "이름은 필수입니다.")
-    private String name;
+  @NotBlank(message = "이름은 필수입니다.")
+  private String name;
 
-    @NotBlank(message = "전화번호는 필수입니다.")
-    @Pattern(
-            regexp = "^\\d{3}-\\d{3,4}-\\d{4}$",
-            message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)"
-    )
-    private String phone;
+  @NotBlank(message = "전화번호는 필수입니다.")
+  @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)")
+  private String phone;
 
-    @NotNull(message = "생년월일은 필수입니다.")
-    @Past(message = "생년월일은 과거 날짜여야 합니다.")
-    private LocalDate birth;
+  @NotNull(message = "생년월일은 필수입니다.")
+  @Past(message = "생년월일은 과거 날짜여야 합니다.")
+  private LocalDate birth;
 }

--- a/account/src/main/java/com/pyokemon/account/user/repository/UserDeviceRepository.java
+++ b/account/src/main/java/com/pyokemon/account/user/repository/UserDeviceRepository.java
@@ -14,7 +14,8 @@ public interface UserDeviceRepository {
 
   List<UserDevice> findByUserId(Long userId);
 
-  Optional<UserDevice> findByUserIdAndDeviceNumberAndIsValid(Long userId, String deviceNumber, boolean isValid);
+  Optional<UserDevice> findByUserIdAndDeviceNumberAndIsValid(Long userId, String deviceNumber,
+      boolean isValid);
 
   boolean existsByDeviceNumberAndIsValid(String deviceNumber, boolean isValid);
 

--- a/account/src/main/java/com/pyokemon/account/user/repository/UserRepository.java
+++ b/account/src/main/java/com/pyokemon/account/user/repository/UserRepository.java
@@ -3,9 +3,9 @@ package com.pyokemon.account.user.repository;
 import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import com.pyokemon.account.user.entity.User;
-import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface UserRepository {

--- a/account/src/main/java/com/pyokemon/account/user/service/UserService.java
+++ b/account/src/main/java/com/pyokemon/account/user/service/UserService.java
@@ -1,22 +1,22 @@
 package com.pyokemon.account.user.service;
 
-import com.pyokemon.account.user.entity.UserDevice;
-import com.pyokemon.common.exception.BusinessException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.pyokemon.account.auth.entity.Account;
+import com.pyokemon.account.auth.entity.AccountStatus;
 import com.pyokemon.account.auth.repository.AccountRepository;
-import com.pyokemon.account.user.dto.request.UpdateUserRequestDto;
-import com.pyokemon.account.user.dto.request.RegisterDeviceRequestDto;
 import com.pyokemon.account.user.dto.request.CreateUserRequestDto;
+import com.pyokemon.account.user.dto.request.RegisterDeviceRequestDto;
+import com.pyokemon.account.user.dto.request.UpdateUserRequestDto;
 import com.pyokemon.account.user.dto.response.UserDetailDto;
 import com.pyokemon.account.user.entity.User;
+import com.pyokemon.account.user.entity.UserDevice;
 import com.pyokemon.account.user.repository.UserDeviceRepository;
 import com.pyokemon.account.user.repository.UserRepository;
+import com.pyokemon.common.exception.BusinessException;
 import com.pyokemon.common.exception.code.AccountErrorCodes;
-import com.pyokemon.account.auth.entity.AccountStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -34,54 +34,39 @@ public class UserService {
   public UserDetailDto registerUser(CreateUserRequestDto request) {
 
     if (accountRepository.existsByLoginIdAndStatus(request.getLoginId(), AccountStatus.ACTIVE)) {
-      throw new BusinessException("이미 존재하는 계정입니다.",AccountErrorCodes.LOGIN_ID_DUPLICATED);
+      throw new BusinessException("이미 존재하는 계정입니다.", AccountErrorCodes.LOGIN_ID_DUPLICATED);
     }
 
-    Account account = Account.builder()
-            .loginId(request.getLoginId())
-            .password(passwordEncoder.encode(request.getPassword()))
-            .role("USER")
-            .status(AccountStatus.ACTIVE)
-            .build();
+    Account account = Account.builder().loginId(request.getLoginId())
+        .password(passwordEncoder.encode(request.getPassword())).role("USER")
+        .status(AccountStatus.ACTIVE).build();
 
     accountRepository.insert(account);
 
-    User user = User.builder()
-            .accountId(account.getAccountId())
-            .name(request.getName())
-            .phone(request.getPhone())
-            .birth(request.getBirth())
-            .build();
+    User user = User.builder().accountId(account.getAccountId()).name(request.getName())
+        .phone(request.getPhone()).birth(request.getBirth()).build();
 
     userRepository.insert(user);
 
-    return UserDetailDto.builder()
-            .loginId(request.getLoginId())
-            .name(request.getName())
-            .phone(request.getPhone())
-            .birth(request.getBirth())
-            .build();
+    return UserDetailDto.builder().loginId(request.getLoginId()).name(request.getName())
+        .phone(request.getPhone()).birth(request.getBirth()).build();
   }
 
   // 사용자 정보 조회
   @Transactional(readOnly = true)
   public UserDetailDto getUserProfile(Long userId) {
-    User user = userRepository.findByUserId(userId)
-        .orElseThrow(() -> new BusinessException("사용자를 찾을 수 없습니다.",AccountErrorCodes.ACCOUNT_NOT_FOUND));
+    User user = userRepository.findByUserId(userId).orElseThrow(
+        () -> new BusinessException("사용자를 찾을 수 없습니다.", AccountErrorCodes.ACCOUNT_NOT_FOUND));
 
-    return UserDetailDto.builder()
-            .name(user.getName())
-            .phone(user.getPhone())
-            .birth(user.getBirth())
-            .build();
+    return UserDetailDto.builder().name(user.getName()).phone(user.getPhone())
+        .birth(user.getBirth()).build();
   }
 
   // 사용자 정보 수정
   @Transactional
-  public UserDetailDto updateUserProfile(Long userId,
-                                         UpdateUserRequestDto request) {
-    User user = userRepository.findByUserId(userId)
-        .orElseThrow(() -> new BusinessException("사용자를 찾을 수 없습니다.",AccountErrorCodes.ACCOUNT_NOT_FOUND));
+  public UserDetailDto updateUserProfile(Long userId, UpdateUserRequestDto request) {
+    User user = userRepository.findByUserId(userId).orElseThrow(
+        () -> new BusinessException("사용자를 찾을 수 없습니다.", AccountErrorCodes.ACCOUNT_NOT_FOUND));
 
     user.setName(request.getName());
     user.setPhone(request.getPhone());
@@ -89,47 +74,41 @@ public class UserService {
 
     userRepository.update(user);
 
-    return UserDetailDto.builder()
-            .name(user.getName())
-            .phone(user.getPhone())
-            .birth(user.getBirth())
-            .build();
+    return UserDetailDto.builder().name(user.getName()).phone(user.getPhone())
+        .birth(user.getBirth()).build();
   }
 
   @Transactional
   public void deleteUser(Long userId) {
-    User user = userRepository.findByUserId(userId)
-        .orElseThrow(() -> new BusinessException("사용자를 찾을 수 없습니다.",AccountErrorCodes.ACCOUNT_NOT_FOUND));
+    User user = userRepository.findByUserId(userId).orElseThrow(
+        () -> new BusinessException("사용자를 찾을 수 없습니다.", AccountErrorCodes.ACCOUNT_NOT_FOUND));
 
-    
+
     accountRepository.updateStatus(user.getAccountId(), AccountStatus.DELETED);
   }
 
   @Transactional
   public void registerUserDevice(Long userId, RegisterDeviceRequestDto request) {
-    User user = userRepository.findByUserId(userId)
-        .orElseThrow(() -> new BusinessException("사용자를 찾을 수 없습니다.",AccountErrorCodes.ACCOUNT_NOT_FOUND));
+    User user = userRepository.findByUserId(userId).orElseThrow(
+        () -> new BusinessException("사용자를 찾을 수 없습니다.", AccountErrorCodes.ACCOUNT_NOT_FOUND));
 
     if (userDeviceRepository.existsByDeviceNumberAndIsValid(request.getDeviceNumber(), true)) {
-      throw new BusinessException("이미 등록된 디바이스입니다.",AccountErrorCodes.DEVICE_ALREADY_REGISTERED);
+      throw new BusinessException("이미 등록된 디바이스입니다.", AccountErrorCodes.DEVICE_ALREADY_REGISTERED);
     }
 
-    UserDevice userDevice = UserDevice.builder()
-            .userId(user.getUserId())
-            .deviceNumber(request.getDeviceNumber())
-            .fcmToken(request.getFcmToken())
-            .osType(request.getOsType())
-            .isValid(true)
-            .build();
+    UserDevice userDevice =
+        UserDevice.builder().userId(user.getUserId()).deviceNumber(request.getDeviceNumber())
+            .fcmToken(request.getFcmToken()).osType(request.getOsType()).isValid(true).build();
 
     userDeviceRepository.insert(userDevice);
   }
 
   @Transactional
   public void deleteUserDevice(Long userId, String deviceNumber) {
-    UserDevice userDevice = userDeviceRepository.findByUserIdAndDeviceNumberAndIsValid(userId, deviceNumber, true)
-        .orElseThrow(() -> new BusinessException("디바이스를 찾을 수 없습니다.",AccountErrorCodes.DEVICE_NOT_FOUND));
-    
+    UserDevice userDevice = userDeviceRepository
+        .findByUserIdAndDeviceNumberAndIsValid(userId, deviceNumber, true).orElseThrow(
+            () -> new BusinessException("디바이스를 찾을 수 없습니다.", AccountErrorCodes.DEVICE_NOT_FOUND));
+
     userDevice.setIsValid(false);
 
     userDeviceRepository.update(userDevice);

--- a/account/src/test/java/com/pyokemon/account/auth/controller/AccountControllerTest.java
+++ b/account/src/test/java/com/pyokemon/account/auth/controller/AccountControllerTest.java
@@ -26,39 +26,35 @@ import com.pyokemon.common.dto.ResponseDto;
 @ExtendWith(MockitoExtension.class)
 public class AccountControllerTest {
 
-    @Mock
-    private AccountService accountService;
-    
-    @InjectMocks
-    private AccountController accountController;
-    
-    private LoginRequestDto loginRequest;
-    private LoginResponseDto loginResponse;
-    private UpdatePasswordRequestDto updatePasswordRequest;
-    
-    @BeforeEach
-    void setUp() {
-        // 테스트용 요청 데이터 생성
-        loginRequest = new LoginRequestDto();
-        loginRequest.setLoginId("test@example.com");
-        loginRequest.setPassword("password123");
-        
-        // 테스트용 응답 데이터 생성
-        loginResponse = LoginResponseDto.builder()
-            .accountId(1L)
-            .role("USER")
-            .accessToken("access-token")
-            .refreshToken("refresh-token")
-            .build();
-        
-        updatePasswordRequest = new UpdatePasswordRequestDto();
-        updatePasswordRequest.setCurrentPassword("oldPassword");
-        updatePasswordRequest.setNewPassword("newPassword123");
-    }
-    
-    // ========== 로그인 테스트 ==========
-    
-    @Test
+  @Mock
+  private AccountService accountService;
+
+  @InjectMocks
+  private AccountController accountController;
+
+  private LoginRequestDto loginRequest;
+  private LoginResponseDto loginResponse;
+  private UpdatePasswordRequestDto updatePasswordRequest;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트용 요청 데이터 생성
+    loginRequest = new LoginRequestDto();
+    loginRequest.setLoginId("test@example.com");
+    loginRequest.setPassword("password123");
+
+    // 테스트용 응답 데이터 생성
+    loginResponse = LoginResponseDto.builder().accountId(1L).role("USER")
+        .accessToken("access-token").refreshToken("refresh-token").build();
+
+    updatePasswordRequest = new UpdatePasswordRequestDto();
+    updatePasswordRequest.setCurrentPassword("oldPassword");
+    updatePasswordRequest.setNewPassword("newPassword123");
+  }
+
+  // ========== 로그인 테스트 ==========
+
+  @Test
     @DisplayName("로그인 성공 테스트")
     void loginSuccess() {
         // given
@@ -75,8 +71,8 @@ public class AccountControllerTest {
         
         verify(accountService).login(loginRequest);
     }
-    
-    @Test
+
+  @Test
     @DisplayName("로그인 실패 테스트")
     void loginFailure() {
         // given
@@ -87,119 +83,122 @@ public class AccountControllerTest {
         
         verify(accountService).login(loginRequest);
     }
-    
-    // ========== 로그아웃 테스트 ==========
-    
-    @Test
-    @DisplayName("로그아웃 성공 테스트")
-    void logoutSuccess() {
-        // given
-        String authHeader = "Bearer valid-token";
-        doNothing().when(accountService).logout(authHeader);
-        
-        // when
-        ResponseEntity<ResponseDto<Void>> response = accountController.logout(authHeader);
-        
-        // then
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertEquals("로그아웃 성공", response.getBody().getMessage());
-        
-        verify(accountService).logout(authHeader);
+
+  // ========== 로그아웃 테스트 ==========
+
+  @Test
+  @DisplayName("로그아웃 성공 테스트")
+  void logoutSuccess() {
+    // given
+    String authHeader = "Bearer valid-token";
+    doNothing().when(accountService).logout(authHeader);
+
+    // when
+    ResponseEntity<ResponseDto<Void>> response = accountController.logout(authHeader);
+
+    // then
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertEquals("로그아웃 성공", response.getBody().getMessage());
+
+    verify(accountService).logout(authHeader);
+  }
+
+  @Test
+  @DisplayName("로그아웃 - Authorization 헤더 없음")
+  void logoutWithoutAuthHeader() {
+    // given
+    String authHeader = null;
+    doNothing().when(accountService).logout(null);
+
+    // when
+    ResponseEntity<ResponseDto<Void>> response = accountController.logout(authHeader);
+
+    // then
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertEquals("로그아웃 성공", response.getBody().getMessage());
+
+    verify(accountService).logout(null);
+  }
+
+  // ========== 토큰 갱신 테스트 ==========
+
+  @Test
+  @DisplayName("토큰 갱신 성공 테스트")
+  void refreshTokenSuccess() {
+    // given
+    String refreshToken = "valid-refresh-token";
+    TokenResponseDto tokenResponse =
+        TokenResponseDto.builder().accessToken("new-access-token").build();
+
+    when(accountService.refreshToken(refreshToken)).thenReturn(tokenResponse);
+
+    // when
+    ResponseEntity<ResponseDto<TokenResponseDto>> response =
+        accountController.refreshToken(refreshToken);
+
+    // then
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertEquals("토큰 갱신 성공", response.getBody().getMessage());
+    assertEquals(tokenResponse, response.getBody().getData());
+
+    verify(accountService).refreshToken(refreshToken);
+  }
+
+  @Test
+  @DisplayName("토큰 갱신 실패 테스트")
+  void refreshTokenFailure() {
+    // given
+    String refreshToken = "invalid-refresh-token";
+    when(accountService.refreshToken(refreshToken))
+        .thenThrow(new RuntimeException("Token refresh failed"));
+
+    // when & then
+    assertThrows(RuntimeException.class, () -> accountController.refreshToken(refreshToken));
+
+    verify(accountService).refreshToken(refreshToken);
+  }
+
+  // ========== 비밀번호 변경 테스트 ==========
+
+  @Test
+  @DisplayName("비밀번호 변경 성공 테스트")
+  void changePasswordSuccess() {
+    // given
+    // GatewayRequestHeaderUtils 모킹을 위해 정적 메소드 모킹 설정
+    try (var gatewayUtilsMock = mockStatic(GatewayRequestHeaderUtils.class)) {
+      gatewayUtilsMock.when(GatewayRequestHeaderUtils::getUserIdOrThrowException).thenReturn("1");
+
+      doNothing().when(accountService).changePassword(1L, updatePasswordRequest);
+
+      // when
+      ResponseEntity<ResponseDto<Void>> response =
+          accountController.changePassword(updatePasswordRequest);
+
+      // then
+      assertEquals(HttpStatus.OK, response.getStatusCode());
+      assertNotNull(response.getBody());
+      assertEquals("비밀번호 변경 성공", response.getBody().getMessage());
+
+      verify(accountService).changePassword(1L, updatePasswordRequest);
     }
-    
-    @Test
-    @DisplayName("로그아웃 - Authorization 헤더 없음")
-    void logoutWithoutAuthHeader() {
-        // given
-        String authHeader = null;
-        doNothing().when(accountService).logout(null);
-        
-        // when
-        ResponseEntity<ResponseDto<Void>> response = accountController.logout(authHeader);
-        
-        // then
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertEquals("로그아웃 성공", response.getBody().getMessage());
-        
-        verify(accountService).logout(null);
+  }
+
+  @Test
+  @DisplayName("비밀번호 변경 실패 - 인증 정보 없음")
+  void changePasswordNoAuthInfo() {
+    // given
+    try (var gatewayUtilsMock = mockStatic(GatewayRequestHeaderUtils.class)) {
+      gatewayUtilsMock.when(GatewayRequestHeaderUtils::getUserIdOrThrowException)
+          .thenThrow(new RuntimeException("No auth info"));
+
+      // when & then
+      assertThrows(RuntimeException.class,
+          () -> accountController.changePassword(updatePasswordRequest));
+
+      verifyNoInteractions(accountService);
     }
-    
-    // ========== 토큰 갱신 테스트 ==========
-    
-    @Test
-    @DisplayName("토큰 갱신 성공 테스트")
-    void refreshTokenSuccess() {
-        // given
-        String refreshToken = "valid-refresh-token";
-        TokenResponseDto tokenResponse = TokenResponseDto.builder()
-            .accessToken("new-access-token")
-            .build();
-        
-        when(accountService.refreshToken(refreshToken)).thenReturn(tokenResponse);
-        
-        // when
-        ResponseEntity<ResponseDto<TokenResponseDto>> response = accountController.refreshToken(refreshToken);
-        
-        // then
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertEquals("토큰 갱신 성공", response.getBody().getMessage());
-        assertEquals(tokenResponse, response.getBody().getData());
-        
-        verify(accountService).refreshToken(refreshToken);
-    }
-    
-    @Test
-    @DisplayName("토큰 갱신 실패 테스트")
-    void refreshTokenFailure() {
-        // given
-        String refreshToken = "invalid-refresh-token";
-        when(accountService.refreshToken(refreshToken)).thenThrow(new RuntimeException("Token refresh failed"));
-        
-        // when & then
-        assertThrows(RuntimeException.class, () -> accountController.refreshToken(refreshToken));
-        
-        verify(accountService).refreshToken(refreshToken);
-    }
-    
-    // ========== 비밀번호 변경 테스트 ==========
-    
-    @Test
-    @DisplayName("비밀번호 변경 성공 테스트")
-    void changePasswordSuccess() {
-        // given
-        // GatewayRequestHeaderUtils 모킹을 위해 정적 메소드 모킹 설정
-        try (var gatewayUtilsMock = mockStatic(GatewayRequestHeaderUtils.class)) {
-            gatewayUtilsMock.when(GatewayRequestHeaderUtils::getUserIdOrThrowException).thenReturn("1");
-            
-            doNothing().when(accountService).changePassword(1L, updatePasswordRequest);
-            
-            // when
-            ResponseEntity<ResponseDto<Void>> response = accountController.changePassword(updatePasswordRequest);
-            
-            // then
-            assertEquals(HttpStatus.OK, response.getStatusCode());
-            assertNotNull(response.getBody());
-            assertEquals("비밀번호 변경 성공", response.getBody().getMessage());
-            
-            verify(accountService).changePassword(1L, updatePasswordRequest);
-        }
-    }
-    
-    @Test
-    @DisplayName("비밀번호 변경 실패 - 인증 정보 없음")
-    void changePasswordNoAuthInfo() {
-        // given
-        try (var gatewayUtilsMock = mockStatic(GatewayRequestHeaderUtils.class)) {
-            gatewayUtilsMock.when(GatewayRequestHeaderUtils::getUserIdOrThrowException)
-                .thenThrow(new RuntimeException("No auth info"));
-            
-            // when & then
-            assertThrows(RuntimeException.class, () -> accountController.changePassword(updatePasswordRequest));
-            
-            verifyNoInteractions(accountService);
-        }
-    }
+  }
 }

--- a/account/src/test/java/com/pyokemon/account/auth/integration/AccountIntegrationTest.java
+++ b/account/src/test/java/com/pyokemon/account/auth/integration/AccountIntegrationTest.java
@@ -28,118 +28,113 @@ import com.pyokemon.account.auth.secret.jwt.TokenGenerator;
 @Transactional
 public class AccountIntegrationTest {
 
-    @Autowired
-    private MockMvc mockMvc;
-    
-    @Autowired
-    private ObjectMapper objectMapper;
-    
-    @Autowired
-    private AccountRepository accountRepository;
-    
-    @Autowired
-    private TokenGenerator tokenGenerator;
-    
-    private Account testAccount;
-    private String validToken;
-    
-    @BeforeEach
-    void setUp() {
-        // 테스트용 계정 생성
-        testAccount = new Account();
-        testAccount.setLoginId("integration@test.com");
-        testAccount.setPassword("$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6Z5EHsM8lE9lBOsl7iKTVEFDa"); // "password123"
-        testAccount.setRole("USER");
-        testAccount.setStatus(AccountStatus.ACTIVE);
-        
-        accountRepository.insert(testAccount);
-        
-        // 유효한 토큰 생성
-        validToken = tokenGenerator.generateAccessToken(testAccount.getAccountId(), testAccount.getRole());
-    }
-    
-    @Test
-    @DisplayName("로그인 통합 테스트 - 성공")
-    void loginIntegrationSuccess() throws Exception {
-        // given
-        LoginRequestDto request = new LoginRequestDto();
-        request.setLoginId("integration@test.com");
-        request.setPassword("password123");
-        
-        // when & then
-        mockMvc.perform(post("/api/login")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.message").value("로그인 성공"))
-            .andExpect(jsonPath("$.data.accessToken").exists())
-            .andExpect(jsonPath("$.data.refreshToken").exists())
-            .andExpect(jsonPath("$.data.role").value("USER"));
-    }
-    
-    @Test
-    @DisplayName("로그인 통합 테스트 - 실패 (잘못된 비밀번호)")
-    void loginIntegrationFailure() throws Exception {
-        // given
-        LoginRequestDto request = new LoginRequestDto();
-        request.setLoginId("integration@test.com");
-        request.setPassword("wrongPassword");
-        
-        // when & then
-        mockMvc.perform(post("/api/login")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.success").value(false));
-    }
-    
-    @Test
-    @DisplayName("토큰 갱신 통합 테스트 - 성공")
-    void refreshTokenIntegrationSuccess() throws Exception {
-        // given
-        String refreshToken = tokenGenerator.generateRefreshToken(testAccount.getAccountId(), testAccount.getRole());
-        
-        // when & then
-        mockMvc.perform(post("/api/refresh")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(refreshToken))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.message").value("토큰 갱신 성공"))
-            .andExpect(jsonPath("$.data.accessToken").exists());
-    }
-    
-    @Test
-    @DisplayName("비밀번호 변경 통합 테스트 - 성공")
-    void changePasswordIntegrationSuccess() throws Exception {
-        // given
-        UpdatePasswordRequestDto request = new UpdatePasswordRequestDto();
-        request.setCurrentPassword("password123");
-        request.setNewPassword("newPassword123");
-        
-        // when & then
-        mockMvc.perform(put("/api/password")
-                .header("X-Auth-UserId", testAccount.getAccountId().toString())
-                .header("X-Auth-UserRole", testAccount.getRole())
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.message").value("비밀번호 변경 성공"));
-    }
-    
-    @Test
-    @DisplayName("로그아웃 통합 테스트 - 성공")
-    void logoutIntegrationSuccess() throws Exception {
-        // given
-        String authHeader = "Bearer " + validToken;
-        
-        // when & then
-        mockMvc.perform(post("/api/logout")
-                .header("Authorization", authHeader))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.message").value("로그아웃 성공"));
-    }
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private AccountRepository accountRepository;
+
+  @Autowired
+  private TokenGenerator tokenGenerator;
+
+  private Account testAccount;
+  private String validToken;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트용 계정 생성
+    testAccount = new Account();
+    testAccount.setLoginId("integration@test.com");
+    testAccount.setPassword("$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6Z5EHsM8lE9lBOsl7iKTVEFDa"); // "password123"
+    testAccount.setRole("USER");
+    testAccount.setStatus(AccountStatus.ACTIVE);
+
+    accountRepository.insert(testAccount);
+
+    // 유효한 토큰 생성
+    validToken =
+        tokenGenerator.generateAccessToken(testAccount.getAccountId(), testAccount.getRole());
+  }
+
+  @Test
+  @DisplayName("로그인 통합 테스트 - 성공")
+  void loginIntegrationSuccess() throws Exception {
+    // given
+    LoginRequestDto request = new LoginRequestDto();
+    request.setLoginId("integration@test.com");
+    request.setPassword("password123");
+
+    // when & then
+    mockMvc
+        .perform(post("/api/login").contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.message").value("로그인 성공"))
+        .andExpect(jsonPath("$.data.accessToken").exists())
+        .andExpect(jsonPath("$.data.refreshToken").exists())
+        .andExpect(jsonPath("$.data.role").value("USER"));
+  }
+
+  @Test
+  @DisplayName("로그인 통합 테스트 - 실패 (잘못된 비밀번호)")
+  void loginIntegrationFailure() throws Exception {
+    // given
+    LoginRequestDto request = new LoginRequestDto();
+    request.setLoginId("integration@test.com");
+    request.setPassword("wrongPassword");
+
+    // when & then
+    mockMvc
+        .perform(post("/api/login").contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest()).andExpect(jsonPath("$.success").value(false));
+  }
+
+  @Test
+  @DisplayName("토큰 갱신 통합 테스트 - 성공")
+  void refreshTokenIntegrationSuccess() throws Exception {
+    // given
+    String refreshToken =
+        tokenGenerator.generateRefreshToken(testAccount.getAccountId(), testAccount.getRole());
+
+    // when & then
+    mockMvc
+        .perform(post("/api/refresh").contentType(MediaType.APPLICATION_JSON).content(refreshToken))
+        .andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.message").value("토큰 갱신 성공"))
+        .andExpect(jsonPath("$.data.accessToken").exists());
+  }
+
+  @Test
+  @DisplayName("비밀번호 변경 통합 테스트 - 성공")
+  void changePasswordIntegrationSuccess() throws Exception {
+    // given
+    UpdatePasswordRequestDto request = new UpdatePasswordRequestDto();
+    request.setCurrentPassword("password123");
+    request.setNewPassword("newPassword123");
+
+    // when & then
+    mockMvc
+        .perform(put("/api/password").header("X-Auth-UserId", testAccount.getAccountId().toString())
+            .header("X-Auth-UserRole", testAccount.getRole())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.message").value("비밀번호 변경 성공"));
+  }
+
+  @Test
+  @DisplayName("로그아웃 통합 테스트 - 성공")
+  void logoutIntegrationSuccess() throws Exception {
+    // given
+    String authHeader = "Bearer " + validToken;
+
+    // when & then
+    mockMvc.perform(post("/api/logout").header("Authorization", authHeader))
+        .andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.message").value("로그아웃 성공"));
+  }
 }

--- a/account/src/test/java/com/pyokemon/account/auth/service/AccountServiceTest.java
+++ b/account/src/test/java/com/pyokemon/account/auth/service/AccountServiceTest.java
@@ -32,406 +32,410 @@ import io.jsonwebtoken.Claims;
 @ExtendWith(MockitoExtension.class)
 public class AccountServiceTest {
 
-    @Mock
-    private AccountRepository accountRepository;
-    
-    @Mock
-    private PasswordEncoder passwordEncoder;
-    
-    @Mock
-    private TokenGenerator tokenGenerator;
-    
-    @Mock
-    private RedisTemplate<String, String> redisTemplate;
-    
-    @Mock
-    private ValueOperations<String, String> valueOperations;
-    
-    @InjectMocks
-    private AccountService accountService;
-    
-    private Account testAccount;
-    
-    @BeforeEach
-    void setUp() {
-        // 테스트용 계정 데이터 생성
-        testAccount = new Account();
-        testAccount.setAccountId(1L);
-        testAccount.setLoginId("test@example.com");
-        testAccount.setPassword("encodedPassword");
-        testAccount.setRole("USER");
-        testAccount.setStatus(AccountStatus.ACTIVE);
-    }
-    
-    @Test
-    @DisplayName("로그인 성공 테스트")
-    void loginSuccess() {
-        // given (테스트 준비)
-        LoginRequestDto request = new LoginRequestDto();
-        request.setLoginId("test@example.com");
-        request.setPassword("password123");
-        
-        // Mock 설정
-        when(accountRepository.findByLoginId("test@example.com")).thenReturn(Optional.of(testAccount));
-        when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(true);
-        when(tokenGenerator.generateAccessToken(1L, "USER")).thenReturn("access-token");
-        when(tokenGenerator.generateRefreshToken(1L, "USER")).thenReturn("refresh-token");
-        
-        // when (테스트 실행)
-        LoginResponseDto response = accountService.login(request);
-        
-        // then (결과 검증)
-        assertNotNull(response);
-        assertEquals("access-token", response.getAccessToken());
-        assertEquals("refresh-token", response.getRefreshToken());
-        assertEquals("USER", response.getRole());
-        assertEquals(1L, response.getAccountId());
-        
-        // Mock 메소드가 호출되었는지 검증
-        verify(accountRepository).findByLoginId("test@example.com");
-        verify(passwordEncoder).matches("password123", "encodedPassword");
-        verify(tokenGenerator).generateAccessToken(1L, "USER");
-        verify(tokenGenerator).generateRefreshToken(1L, "USER");
-    }
-    
-    @Test
-    @DisplayName("로그인 실패 - 계정 없음")
-    void loginFailAccountNotFound() {
-        // given
-        LoginRequestDto request = new LoginRequestDto();
-        request.setLoginId("nonexistent@example.com");
-        request.setPassword("password123");
-        
-        when(accountRepository.findByLoginId("nonexistent@example.com")).thenReturn(Optional.empty());
-        
-        // when & then
-        assertThrows(BusinessException.class, () -> accountService.login(request));
-        
-        verify(accountRepository).findByLoginId("nonexistent@example.com");
-        verifyNoInteractions(passwordEncoder);
-        verifyNoInteractions(tokenGenerator);
-    }
-    
-    @Test
-    @DisplayName("로그인 실패 - 비밀번호 불일치")
-    void loginFailPasswordMismatch() {
-        // given
-        LoginRequestDto request = new LoginRequestDto();
-        request.setLoginId("test@example.com");
-        request.setPassword("wrongPassword");
-        
-        when(accountRepository.findByLoginId("test@example.com")).thenReturn(Optional.of(testAccount));
-        when(passwordEncoder.matches("wrongPassword", "encodedPassword")).thenReturn(false);
-        
-        // when & then
-        assertThrows(BusinessException.class, () -> accountService.login(request));
-        
-        verify(accountRepository).findByLoginId("test@example.com");
-        verify(passwordEncoder).matches("wrongPassword", "encodedPassword");
-        verifyNoInteractions(tokenGenerator);
-    }
-    
-    @Test
-    @DisplayName("로그인 실패 - 삭제된 계정")
-    void loginFailDeletedAccount() {
-        // given
-        testAccount.setStatus(AccountStatus.DELETED);
-        LoginRequestDto request = new LoginRequestDto();
-        request.setLoginId("test@example.com");
-        request.setPassword("password123");
-        
-        when(accountRepository.findByLoginId("test@example.com")).thenReturn(Optional.of(testAccount));
-        
-        // when & then
-        assertThrows(BusinessException.class, () -> accountService.login(request));
-        
-        verify(accountRepository).findByLoginId("test@example.com");
-        verifyNoInteractions(passwordEncoder);
-        verifyNoInteractions(tokenGenerator);
-    }
-    
-    // ========== 로그아웃 테스트 ==========
-    
-    @Test
-    @DisplayName("로그아웃 성공 테스트")
-    void logoutSuccess() {
-        // given
-        String token = "Bearer valid-token";
-        Claims claims = mock(Claims.class);
-        
-        when(tokenGenerator.parseToken("valid-token")).thenReturn(claims);
-        when(claims.getExpiration()).thenReturn(new java.util.Date(System.currentTimeMillis() + 3600000)); // 1시간 후
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-        
-        // when
-        accountService.logout(token);
-        
-        // then
-        verify(tokenGenerator).parseToken("valid-token");
-        verify(claims).getExpiration();
-        verify(redisTemplate).opsForValue();
-        verify(valueOperations).set(eq("blacklist:valid-token"), eq("blacklisted"), anyLong(), eq(java.util.concurrent.TimeUnit.SECONDS));
-    }
-    
-    @Test
-    @DisplayName("로그아웃 - Bearer 접두사 없는 토큰")
-    void logoutWithoutBearerPrefix() {
-        // given
-        String token = "valid-token";
-        Claims claims = mock(Claims.class);
-        
-        when(tokenGenerator.parseToken("valid-token")).thenReturn(claims);
-        when(claims.getExpiration()).thenReturn(new java.util.Date(System.currentTimeMillis() + 3600000));
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-        
-        // when
-        accountService.logout(token);
-        
-        // then
-        verify(tokenGenerator).parseToken("valid-token");
-        verify(redisTemplate).opsForValue();
-    }
-    
-    @Test
-    @DisplayName("로그아웃 - 토큰 파싱 실패")
-    void logoutTokenParseFailure() {
-        // given
-        String token = "Bearer invalid-token";
-        
-        when(tokenGenerator.parseToken("invalid-token")).thenThrow(new RuntimeException("Invalid token"));
-        
-        // when & then (예외가 발생하지 않아야 함)
-        assertDoesNotThrow(() -> accountService.logout(token));
-        
-        verify(tokenGenerator).parseToken("invalid-token");
-        verifyNoInteractions(redisTemplate);
-    }
-    
-    // ========== 토큰 갱신 테스트 ==========
-    
-    @Test
-    @DisplayName("토큰 갱신 성공 테스트")
-    void refreshTokenSuccess() {
-        // given
-        String refreshToken = "valid-refresh-token";
-        Claims claims = mock(Claims.class);
-        
-        when(tokenGenerator.validateToken(refreshToken)).thenReturn(true);
-        when(redisTemplate.hasKey("blacklist:" + refreshToken)).thenReturn(false);
-        when(tokenGenerator.parseToken(refreshToken)).thenReturn(claims);
-        when(claims.getSubject()).thenReturn("1");
-        when(claims.get("role", String.class)).thenReturn("USER");
-        when(accountRepository.findByAccountId(1L)).thenReturn(Optional.of(testAccount));
-        when(tokenGenerator.generateAccessToken(1L, "USER")).thenReturn("new-access-token");
-        
-        // when
-        TokenResponseDto response = accountService.refreshToken(refreshToken);
-        
-        // then
-        assertNotNull(response);
-        assertEquals("new-access-token", response.getAccessToken());
-        
-        verify(tokenGenerator).validateToken(refreshToken);
-        verify(redisTemplate).hasKey("blacklist:" + refreshToken);
-        verify(tokenGenerator).parseToken(refreshToken);
-        verify(accountRepository).findByAccountId(1L);
-        verify(tokenGenerator).generateAccessToken(1L, "USER");
-    }
-    
-    @Test
-    @DisplayName("토큰 갱신 실패 - 유효하지 않은 토큰")
-    void refreshTokenInvalidToken() {
-        // given
-        String refreshToken = "invalid-refresh-token";
-        
-        when(tokenGenerator.validateToken(refreshToken)).thenReturn(false);
-        
-        // when & then
-        assertThrows(BusinessException.class, () -> accountService.refreshToken(refreshToken));
-        
-        verify(tokenGenerator).validateToken(refreshToken);
-        verifyNoInteractions(redisTemplate);
-        verifyNoInteractions(accountRepository);
-    }
-    
-    @Test
-    @DisplayName("토큰 갱신 실패 - 블랙리스트된 토큰")
-    void refreshTokenBlacklistedToken() {
-        // given
-        String refreshToken = "blacklisted-token";
-        
-        when(tokenGenerator.validateToken(refreshToken)).thenReturn(true);
-        when(redisTemplate.hasKey("blacklist:" + refreshToken)).thenReturn(true);
-        
-        // when & then
-        assertThrows(BusinessException.class, () -> accountService.refreshToken(refreshToken));
-        
-        verify(tokenGenerator).validateToken(refreshToken);
-        verify(redisTemplate).hasKey("blacklist:" + refreshToken);
-        verifyNoInteractions(accountRepository);
-    }
-    
-    @Test
-    @DisplayName("토큰 갱신 실패 - 계정 없음")
-    void refreshTokenAccountNotFound() {
-        // given
-        String refreshToken = "valid-refresh-token";
-        Claims claims = mock(Claims.class);
-        
-        when(tokenGenerator.validateToken(refreshToken)).thenReturn(true);
-        when(redisTemplate.hasKey("blacklist:" + refreshToken)).thenReturn(false);
-        when(tokenGenerator.parseToken(refreshToken)).thenReturn(claims);
-        when(claims.getSubject()).thenReturn("999");
-        when(claims.get("role", String.class)).thenReturn("USER");
-        when(accountRepository.findByAccountId(999L)).thenReturn(Optional.empty());
-        
-        // when & then
-        assertThrows(BusinessException.class, () -> accountService.refreshToken(refreshToken));
-        
-        verify(tokenGenerator).validateToken(refreshToken);
-        verify(redisTemplate).hasKey("blacklist:" + refreshToken);
-        verify(tokenGenerator).parseToken(refreshToken);
-        verify(accountRepository).findByAccountId(999L);
-    }
-    
-    @Test
-    @DisplayName("토큰 갱신 실패 - 삭제된 계정")
-    void refreshTokenDeletedAccount() {
-        // given
-        String refreshToken = "valid-refresh-token";
-        Claims claims = mock(Claims.class);
-        testAccount.setStatus(AccountStatus.DELETED);
-        
-        when(tokenGenerator.validateToken(refreshToken)).thenReturn(true);
-        when(redisTemplate.hasKey("blacklist:" + refreshToken)).thenReturn(false);
-        when(tokenGenerator.parseToken(refreshToken)).thenReturn(claims);
-        when(claims.getSubject()).thenReturn("1");
-        when(claims.get("role", String.class)).thenReturn("USER");
-        when(accountRepository.findByAccountId(1L)).thenReturn(Optional.of(testAccount));
-        
-        // when & then
-        assertThrows(BusinessException.class, () -> accountService.refreshToken(refreshToken));
-        
-        verify(tokenGenerator).validateToken(refreshToken);
-        verify(redisTemplate).hasKey("blacklist:" + refreshToken);
-        verify(tokenGenerator).parseToken(refreshToken);
-        verify(accountRepository).findByAccountId(1L);
-    }
-    
-    // ========== 비밀번호 변경 테스트 ==========
-    
-    @Test
-    @DisplayName("비밀번호 변경 성공 테스트")
-    void changePasswordSuccess() {
-        // given
-        Long accountId = 1L;
-        UpdatePasswordRequestDto request = new UpdatePasswordRequestDto();
-        request.setCurrentPassword("oldPassword");
-        request.setNewPassword("newPassword123");
-        
-        when(accountRepository.findByAccountId(accountId)).thenReturn(Optional.of(testAccount));
-        when(passwordEncoder.matches("oldPassword", "encodedPassword")).thenReturn(true);
-        when(passwordEncoder.matches("newPassword123", "encodedPassword")).thenReturn(false);
-        when(passwordEncoder.encode("newPassword123")).thenReturn("newEncodedPassword");
-        when(accountRepository.update(any(Account.class))).thenReturn(1);
-        
-        // when
-        accountService.changePassword(accountId, request);
-        
-        // then
-        verify(accountRepository).findByAccountId(accountId);
-        verify(passwordEncoder).matches("oldPassword", "encodedPassword");
-        verify(passwordEncoder).matches("newPassword123", "encodedPassword");
-        verify(passwordEncoder).encode("newPassword123");
-        verify(accountRepository).update(any(Account.class));
-    }
-    
-    @Test
-    @DisplayName("비밀번호 변경 실패 - 계정 없음")
-    void changePasswordAccountNotFound() {
-        // given
-        Long accountId = 999L;
-        UpdatePasswordRequestDto request = new UpdatePasswordRequestDto();
-        request.setCurrentPassword("oldPassword");
-        request.setNewPassword("newPassword123");
-        
-        when(accountRepository.findByAccountId(accountId)).thenReturn(Optional.empty());
-        
-        // when & then
-        assertThrows(BusinessException.class, () -> accountService.changePassword(accountId, request));
-        
-        verify(accountRepository).findByAccountId(accountId);
-        verifyNoInteractions(passwordEncoder);
-    }
-    
-    @Test
-    @DisplayName("비밀번호 변경 실패 - 현재 비밀번호 불일치")
-    void changePasswordCurrentPasswordMismatch() {
-        // given
-        Long accountId = 1L;
-        UpdatePasswordRequestDto request = new UpdatePasswordRequestDto();
-        request.setCurrentPassword("wrongPassword");
-        request.setNewPassword("newPassword123");
-        
-        when(accountRepository.findByAccountId(accountId)).thenReturn(Optional.of(testAccount));
-        when(passwordEncoder.matches("wrongPassword", "encodedPassword")).thenReturn(false);
-        
-        // when & then
-        assertThrows(BusinessException.class, () -> accountService.changePassword(accountId, request));
-        
-        verify(accountRepository).findByAccountId(accountId);
-        verify(passwordEncoder).matches("wrongPassword", "encodedPassword");
-    }
-    
-    @Test
-    @DisplayName("비밀번호 변경 실패 - 새 비밀번호가 현재 비밀번호와 동일")
-    void changePasswordNewPasswordSameAsCurrent() {
-        // given
-        Long accountId = 1L;
-        UpdatePasswordRequestDto request = new UpdatePasswordRequestDto();
-        request.setCurrentPassword("oldPassword");
-        request.setNewPassword("oldPassword");
-        
-        when(accountRepository.findByAccountId(accountId)).thenReturn(Optional.of(testAccount));
-        when(passwordEncoder.matches("oldPassword", "encodedPassword")).thenReturn(true);
-        
-        // when & then
-        assertThrows(BusinessException.class, () -> accountService.changePassword(accountId, request));
-        
-        verify(accountRepository).findByAccountId(accountId);
-        verify(passwordEncoder, times(2)).matches("oldPassword", "encodedPassword");
-    }
-    
-    // ========== 계정 삭제 테스트 ==========
-    
-    @Test
-    @DisplayName("계정 삭제 성공 테스트")
-    void deleteAccountSuccess() {
-        // given
-        Long accountId = 1L;
-        
-        when(accountRepository.findByAccountId(accountId)).thenReturn(Optional.of(testAccount));
-        when(accountRepository.updateStatus(accountId, AccountStatus.DELETED)).thenReturn(1);
-        
-        // when
-        accountService.deleteAccount(accountId);
-        
-        // then
-        verify(accountRepository).findByAccountId(accountId);
-        verify(accountRepository).updateStatus(accountId, AccountStatus.DELETED);
-    }
-    
-    @Test
-    @DisplayName("계정 삭제 실패 - 계정 없음")
-    void deleteAccountNotFound() {
-        // given
-        Long accountId = 999L;
-        
-        when(accountRepository.findByAccountId(accountId)).thenReturn(Optional.empty());
-        
-        // when & then
-        assertThrows(BusinessException.class, () -> accountService.deleteAccount(accountId));
-        
-        verify(accountRepository).findByAccountId(accountId);
-    }
+  @Mock
+  private AccountRepository accountRepository;
+
+  @Mock
+  private PasswordEncoder passwordEncoder;
+
+  @Mock
+  private TokenGenerator tokenGenerator;
+
+  @Mock
+  private RedisTemplate<String, String> redisTemplate;
+
+  @Mock
+  private ValueOperations<String, String> valueOperations;
+
+  @InjectMocks
+  private AccountService accountService;
+
+  private Account testAccount;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트용 계정 데이터 생성
+    testAccount = new Account();
+    testAccount.setAccountId(1L);
+    testAccount.setLoginId("test@example.com");
+    testAccount.setPassword("encodedPassword");
+    testAccount.setRole("USER");
+    testAccount.setStatus(AccountStatus.ACTIVE);
+  }
+
+  @Test
+  @DisplayName("로그인 성공 테스트")
+  void loginSuccess() {
+    // given (테스트 준비)
+    LoginRequestDto request = new LoginRequestDto();
+    request.setLoginId("test@example.com");
+    request.setPassword("password123");
+
+    // Mock 설정
+    when(accountRepository.findByLoginId("test@example.com")).thenReturn(Optional.of(testAccount));
+    when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(true);
+    when(tokenGenerator.generateAccessToken(1L, "USER")).thenReturn("access-token");
+    when(tokenGenerator.generateRefreshToken(1L, "USER")).thenReturn("refresh-token");
+
+    // when (테스트 실행)
+    LoginResponseDto response = accountService.login(request);
+
+    // then (결과 검증)
+    assertNotNull(response);
+    assertEquals("access-token", response.getAccessToken());
+    assertEquals("refresh-token", response.getRefreshToken());
+    assertEquals("USER", response.getRole());
+    assertEquals(1L, response.getAccountId());
+
+    // Mock 메소드가 호출되었는지 검증
+    verify(accountRepository).findByLoginId("test@example.com");
+    verify(passwordEncoder).matches("password123", "encodedPassword");
+    verify(tokenGenerator).generateAccessToken(1L, "USER");
+    verify(tokenGenerator).generateRefreshToken(1L, "USER");
+  }
+
+  @Test
+  @DisplayName("로그인 실패 - 계정 없음")
+  void loginFailAccountNotFound() {
+    // given
+    LoginRequestDto request = new LoginRequestDto();
+    request.setLoginId("nonexistent@example.com");
+    request.setPassword("password123");
+
+    when(accountRepository.findByLoginId("nonexistent@example.com")).thenReturn(Optional.empty());
+
+    // when & then
+    assertThrows(BusinessException.class, () -> accountService.login(request));
+
+    verify(accountRepository).findByLoginId("nonexistent@example.com");
+    verifyNoInteractions(passwordEncoder);
+    verifyNoInteractions(tokenGenerator);
+  }
+
+  @Test
+  @DisplayName("로그인 실패 - 비밀번호 불일치")
+  void loginFailPasswordMismatch() {
+    // given
+    LoginRequestDto request = new LoginRequestDto();
+    request.setLoginId("test@example.com");
+    request.setPassword("wrongPassword");
+
+    when(accountRepository.findByLoginId("test@example.com")).thenReturn(Optional.of(testAccount));
+    when(passwordEncoder.matches("wrongPassword", "encodedPassword")).thenReturn(false);
+
+    // when & then
+    assertThrows(BusinessException.class, () -> accountService.login(request));
+
+    verify(accountRepository).findByLoginId("test@example.com");
+    verify(passwordEncoder).matches("wrongPassword", "encodedPassword");
+    verifyNoInteractions(tokenGenerator);
+  }
+
+  @Test
+  @DisplayName("로그인 실패 - 삭제된 계정")
+  void loginFailDeletedAccount() {
+    // given
+    testAccount.setStatus(AccountStatus.DELETED);
+    LoginRequestDto request = new LoginRequestDto();
+    request.setLoginId("test@example.com");
+    request.setPassword("password123");
+
+    when(accountRepository.findByLoginId("test@example.com")).thenReturn(Optional.of(testAccount));
+
+    // when & then
+    assertThrows(BusinessException.class, () -> accountService.login(request));
+
+    verify(accountRepository).findByLoginId("test@example.com");
+    verifyNoInteractions(passwordEncoder);
+    verifyNoInteractions(tokenGenerator);
+  }
+
+  // ========== 로그아웃 테스트 ==========
+
+  @Test
+  @DisplayName("로그아웃 성공 테스트")
+  void logoutSuccess() {
+    // given
+    String token = "Bearer valid-token";
+    Claims claims = mock(Claims.class);
+
+    when(tokenGenerator.parseToken("valid-token")).thenReturn(claims);
+    when(claims.getExpiration())
+        .thenReturn(new java.util.Date(System.currentTimeMillis() + 3600000)); // 1시간 후
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+    // when
+    accountService.logout(token);
+
+    // then
+    verify(tokenGenerator).parseToken("valid-token");
+    verify(claims).getExpiration();
+    verify(redisTemplate).opsForValue();
+    verify(valueOperations).set(eq("blacklist:valid-token"), eq("blacklisted"), anyLong(),
+        eq(java.util.concurrent.TimeUnit.SECONDS));
+  }
+
+  @Test
+  @DisplayName("로그아웃 - Bearer 접두사 없는 토큰")
+  void logoutWithoutBearerPrefix() {
+    // given
+    String token = "valid-token";
+    Claims claims = mock(Claims.class);
+
+    when(tokenGenerator.parseToken("valid-token")).thenReturn(claims);
+    when(claims.getExpiration())
+        .thenReturn(new java.util.Date(System.currentTimeMillis() + 3600000));
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+    // when
+    accountService.logout(token);
+
+    // then
+    verify(tokenGenerator).parseToken("valid-token");
+    verify(redisTemplate).opsForValue();
+  }
+
+  @Test
+  @DisplayName("로그아웃 - 토큰 파싱 실패")
+  void logoutTokenParseFailure() {
+    // given
+    String token = "Bearer invalid-token";
+
+    when(tokenGenerator.parseToken("invalid-token"))
+        .thenThrow(new RuntimeException("Invalid token"));
+
+    // when & then (예외가 발생하지 않아야 함)
+    assertDoesNotThrow(() -> accountService.logout(token));
+
+    verify(tokenGenerator).parseToken("invalid-token");
+    verifyNoInteractions(redisTemplate);
+  }
+
+  // ========== 토큰 갱신 테스트 ==========
+
+  @Test
+  @DisplayName("토큰 갱신 성공 테스트")
+  void refreshTokenSuccess() {
+    // given
+    String refreshToken = "valid-refresh-token";
+    Claims claims = mock(Claims.class);
+
+    when(tokenGenerator.validateToken(refreshToken)).thenReturn(true);
+    when(redisTemplate.hasKey("blacklist:" + refreshToken)).thenReturn(false);
+    when(tokenGenerator.parseToken(refreshToken)).thenReturn(claims);
+    when(claims.getSubject()).thenReturn("1");
+    when(claims.get("role", String.class)).thenReturn("USER");
+    when(accountRepository.findByAccountId(1L)).thenReturn(Optional.of(testAccount));
+    when(tokenGenerator.generateAccessToken(1L, "USER")).thenReturn("new-access-token");
+
+    // when
+    TokenResponseDto response = accountService.refreshToken(refreshToken);
+
+    // then
+    assertNotNull(response);
+    assertEquals("new-access-token", response.getAccessToken());
+
+    verify(tokenGenerator).validateToken(refreshToken);
+    verify(redisTemplate).hasKey("blacklist:" + refreshToken);
+    verify(tokenGenerator).parseToken(refreshToken);
+    verify(accountRepository).findByAccountId(1L);
+    verify(tokenGenerator).generateAccessToken(1L, "USER");
+  }
+
+  @Test
+  @DisplayName("토큰 갱신 실패 - 유효하지 않은 토큰")
+  void refreshTokenInvalidToken() {
+    // given
+    String refreshToken = "invalid-refresh-token";
+
+    when(tokenGenerator.validateToken(refreshToken)).thenReturn(false);
+
+    // when & then
+    assertThrows(BusinessException.class, () -> accountService.refreshToken(refreshToken));
+
+    verify(tokenGenerator).validateToken(refreshToken);
+    verifyNoInteractions(redisTemplate);
+    verifyNoInteractions(accountRepository);
+  }
+
+  @Test
+  @DisplayName("토큰 갱신 실패 - 블랙리스트된 토큰")
+  void refreshTokenBlacklistedToken() {
+    // given
+    String refreshToken = "blacklisted-token";
+
+    when(tokenGenerator.validateToken(refreshToken)).thenReturn(true);
+    when(redisTemplate.hasKey("blacklist:" + refreshToken)).thenReturn(true);
+
+    // when & then
+    assertThrows(BusinessException.class, () -> accountService.refreshToken(refreshToken));
+
+    verify(tokenGenerator).validateToken(refreshToken);
+    verify(redisTemplate).hasKey("blacklist:" + refreshToken);
+    verifyNoInteractions(accountRepository);
+  }
+
+  @Test
+  @DisplayName("토큰 갱신 실패 - 계정 없음")
+  void refreshTokenAccountNotFound() {
+    // given
+    String refreshToken = "valid-refresh-token";
+    Claims claims = mock(Claims.class);
+
+    when(tokenGenerator.validateToken(refreshToken)).thenReturn(true);
+    when(redisTemplate.hasKey("blacklist:" + refreshToken)).thenReturn(false);
+    when(tokenGenerator.parseToken(refreshToken)).thenReturn(claims);
+    when(claims.getSubject()).thenReturn("999");
+    when(claims.get("role", String.class)).thenReturn("USER");
+    when(accountRepository.findByAccountId(999L)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThrows(BusinessException.class, () -> accountService.refreshToken(refreshToken));
+
+    verify(tokenGenerator).validateToken(refreshToken);
+    verify(redisTemplate).hasKey("blacklist:" + refreshToken);
+    verify(tokenGenerator).parseToken(refreshToken);
+    verify(accountRepository).findByAccountId(999L);
+  }
+
+  @Test
+  @DisplayName("토큰 갱신 실패 - 삭제된 계정")
+  void refreshTokenDeletedAccount() {
+    // given
+    String refreshToken = "valid-refresh-token";
+    Claims claims = mock(Claims.class);
+    testAccount.setStatus(AccountStatus.DELETED);
+
+    when(tokenGenerator.validateToken(refreshToken)).thenReturn(true);
+    when(redisTemplate.hasKey("blacklist:" + refreshToken)).thenReturn(false);
+    when(tokenGenerator.parseToken(refreshToken)).thenReturn(claims);
+    when(claims.getSubject()).thenReturn("1");
+    when(claims.get("role", String.class)).thenReturn("USER");
+    when(accountRepository.findByAccountId(1L)).thenReturn(Optional.of(testAccount));
+
+    // when & then
+    assertThrows(BusinessException.class, () -> accountService.refreshToken(refreshToken));
+
+    verify(tokenGenerator).validateToken(refreshToken);
+    verify(redisTemplate).hasKey("blacklist:" + refreshToken);
+    verify(tokenGenerator).parseToken(refreshToken);
+    verify(accountRepository).findByAccountId(1L);
+  }
+
+  // ========== 비밀번호 변경 테스트 ==========
+
+  @Test
+  @DisplayName("비밀번호 변경 성공 테스트")
+  void changePasswordSuccess() {
+    // given
+    Long accountId = 1L;
+    UpdatePasswordRequestDto request = new UpdatePasswordRequestDto();
+    request.setCurrentPassword("oldPassword");
+    request.setNewPassword("newPassword123");
+
+    when(accountRepository.findByAccountId(accountId)).thenReturn(Optional.of(testAccount));
+    when(passwordEncoder.matches("oldPassword", "encodedPassword")).thenReturn(true);
+    when(passwordEncoder.matches("newPassword123", "encodedPassword")).thenReturn(false);
+    when(passwordEncoder.encode("newPassword123")).thenReturn("newEncodedPassword");
+    when(accountRepository.update(any(Account.class))).thenReturn(1);
+
+    // when
+    accountService.changePassword(accountId, request);
+
+    // then
+    verify(accountRepository).findByAccountId(accountId);
+    verify(passwordEncoder).matches("oldPassword", "encodedPassword");
+    verify(passwordEncoder).matches("newPassword123", "encodedPassword");
+    verify(passwordEncoder).encode("newPassword123");
+    verify(accountRepository).update(any(Account.class));
+  }
+
+  @Test
+  @DisplayName("비밀번호 변경 실패 - 계정 없음")
+  void changePasswordAccountNotFound() {
+    // given
+    Long accountId = 999L;
+    UpdatePasswordRequestDto request = new UpdatePasswordRequestDto();
+    request.setCurrentPassword("oldPassword");
+    request.setNewPassword("newPassword123");
+
+    when(accountRepository.findByAccountId(accountId)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThrows(BusinessException.class, () -> accountService.changePassword(accountId, request));
+
+    verify(accountRepository).findByAccountId(accountId);
+    verifyNoInteractions(passwordEncoder);
+  }
+
+  @Test
+  @DisplayName("비밀번호 변경 실패 - 현재 비밀번호 불일치")
+  void changePasswordCurrentPasswordMismatch() {
+    // given
+    Long accountId = 1L;
+    UpdatePasswordRequestDto request = new UpdatePasswordRequestDto();
+    request.setCurrentPassword("wrongPassword");
+    request.setNewPassword("newPassword123");
+
+    when(accountRepository.findByAccountId(accountId)).thenReturn(Optional.of(testAccount));
+    when(passwordEncoder.matches("wrongPassword", "encodedPassword")).thenReturn(false);
+
+    // when & then
+    assertThrows(BusinessException.class, () -> accountService.changePassword(accountId, request));
+
+    verify(accountRepository).findByAccountId(accountId);
+    verify(passwordEncoder).matches("wrongPassword", "encodedPassword");
+  }
+
+  @Test
+  @DisplayName("비밀번호 변경 실패 - 새 비밀번호가 현재 비밀번호와 동일")
+  void changePasswordNewPasswordSameAsCurrent() {
+    // given
+    Long accountId = 1L;
+    UpdatePasswordRequestDto request = new UpdatePasswordRequestDto();
+    request.setCurrentPassword("oldPassword");
+    request.setNewPassword("oldPassword");
+
+    when(accountRepository.findByAccountId(accountId)).thenReturn(Optional.of(testAccount));
+    when(passwordEncoder.matches("oldPassword", "encodedPassword")).thenReturn(true);
+
+    // when & then
+    assertThrows(BusinessException.class, () -> accountService.changePassword(accountId, request));
+
+    verify(accountRepository).findByAccountId(accountId);
+    verify(passwordEncoder, times(2)).matches("oldPassword", "encodedPassword");
+  }
+
+  // ========== 계정 삭제 테스트 ==========
+
+  @Test
+  @DisplayName("계정 삭제 성공 테스트")
+  void deleteAccountSuccess() {
+    // given
+    Long accountId = 1L;
+
+    when(accountRepository.findByAccountId(accountId)).thenReturn(Optional.of(testAccount));
+    when(accountRepository.updateStatus(accountId, AccountStatus.DELETED)).thenReturn(1);
+
+    // when
+    accountService.deleteAccount(accountId);
+
+    // then
+    verify(accountRepository).findByAccountId(accountId);
+    verify(accountRepository).updateStatus(accountId, AccountStatus.DELETED);
+  }
+
+  @Test
+  @DisplayName("계정 삭제 실패 - 계정 없음")
+  void deleteAccountNotFound() {
+    // given
+    Long accountId = 999L;
+
+    when(accountRepository.findByAccountId(accountId)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThrows(BusinessException.class, () -> accountService.deleteAccount(accountId));
+
+    verify(accountRepository).findByAccountId(accountId);
+  }
 }

--- a/common/src/main/java/com/pyokemon/common/config/JacksonConfig.java
+++ b/common/src/main/java/com/pyokemon/common/config/JacksonConfig.java
@@ -35,12 +35,12 @@ public class JacksonConfig {
     @Override
     public LocalDate deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
       String dateStr = p.getText();
-      
+
       // 빈 문자열이나 "invalid-date" 같은 특수 값 처리
       if (dateStr == null || dateStr.isEmpty() || "invalid-date".equals(dateStr)) {
         return null; // 또는 기본값 반환
       }
-      
+
       try {
         return LocalDate.parse(dateStr, FORMATTER);
       } catch (DateTimeParseException e) {
@@ -67,7 +67,7 @@ public class JacksonConfig {
     // Java 8 시간 API 지원
     mapper.registerModule(new JavaTimeModule());
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-    
+
     // 커스텀 LocalDate 역직렬화기 등록
     SimpleModule module = new SimpleModule();
     module.addDeserializer(LocalDate.class, new CustomLocalDateDeserializer());

--- a/common/src/main/java/com/pyokemon/common/config/WebConfig.java
+++ b/common/src/main/java/com/pyokemon/common/config/WebConfig.java
@@ -10,9 +10,9 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/**")
-        .allowedOrigins("https://pyokemon.synology.me", "https://pyokemon.synology.me/user", "http://localhost:5173","http://localhost:6080" )
-        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-        .allowedHeaders("*")
+        .allowedOrigins("https://pyokemon.synology.me", "https://pyokemon.synology.me/user",
+            "http://localhost:5173", "http://localhost:6080")
+        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS").allowedHeaders("*")
         .allowCredentials(true);
   }
 }

--- a/common/src/main/java/com/pyokemon/common/config/WebConfig.java
+++ b/common/src/main/java/com/pyokemon/common/config/WebConfig.java
@@ -1,18 +1,18 @@
-//package com.pyokemon.common.config;
-//
-//import org.springframework.context.annotation.Configuration;
-//import org.springframework.web.servlet.config.annotation.CorsRegistry;
-//import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-//
-//@Configuration
-//public class WebConfig implements WebMvcConfigurer {
-//
-//  @Override
-//  public void addCorsMappings(CorsRegistry registry) {
-//    registry.addMapping("/**")
-//        .allowedOrigins("https://pyokemon.synology.me", "https://pyokemon.synology.me/user", "http://localhost:5173","http://localhost:6080" )
-//        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-//        .allowedHeaders("*")
-//        .allowCredentials(true);
-//  }
-//}
+package com.pyokemon.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/**")
+        .allowedOrigins("https://pyokemon.synology.me", "https://pyokemon.synology.me/user", "http://localhost:5173","http://localhost:6080" )
+        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+        .allowedHeaders("*")
+        .allowCredentials(true);
+  }
+}

--- a/common/src/main/java/com/pyokemon/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/pyokemon/common/exception/GlobalExceptionHandler.java
@@ -30,7 +30,8 @@ public class GlobalExceptionHandler {
   }
 
   @ExceptionHandler(AuthenticationException.class)
-  public ResponseEntity<ResponseDto<Void>> handleAuthenticationException(AuthenticationException e) {
+  public ResponseEntity<ResponseDto<Void>> handleAuthenticationException(
+      AuthenticationException e) {
     log.error("Authentication exception occurred: {}", e.getMessage(), e);
 
     ResponseDto<Void> response = ResponseDto.error("인증이 필요합니다.", "ACCESS_DENIED");
@@ -65,22 +66,19 @@ public class GlobalExceptionHandler {
   }
 
   @ExceptionHandler(InvalidFormatException.class)
-  public ResponseEntity<ResponseDto<Map<String, String>>> handleInvalidFormatException(InvalidFormatException e) {
+  public ResponseEntity<ResponseDto<Map<String, String>>> handleInvalidFormatException(
+      InvalidFormatException e) {
     log.error("Invalid format exception occurred: {}", e.getMessage(), e);
-    
+
     Map<String, String> errors = new HashMap<>();
     String fieldName = e.getPath().isEmpty() ? "unknown" : e.getPath().get(0).getFieldName();
-    String errorMessage = String.format("잘못된 형식의 데이터입니다. 입력값: '%s', 필요한 타입: %s", 
-        e.getValue(), e.getTargetType().getSimpleName());
+    String errorMessage = String.format("잘못된 형식의 데이터입니다. 입력값: '%s', 필요한 타입: %s", e.getValue(),
+        e.getTargetType().getSimpleName());
     errors.put(fieldName, errorMessage);
-    
+
     ResponseDto<Map<String, String>> response = ResponseDto.<Map<String, String>>builder()
-        .success(false)
-        .message("데이터 형식 오류")
-        .errorCode("INVALID_FORMAT")
-        .data(errors)
-        .build();
-        
+        .success(false).message("데이터 형식 오류").errorCode("INVALID_FORMAT").data(errors).build();
+
     return ResponseEntity.badRequest().body(response);
   }
 

--- a/event/src/main/java/com/pyokemon/event/controller/EventController.java
+++ b/event/src/main/java/com/pyokemon/event/controller/EventController.java
@@ -13,6 +13,7 @@ import com.pyokemon.event.dto.EventDetailResponseDTO;
 import com.pyokemon.event.dto.EventItemResponseDTO;
 import com.pyokemon.event.dto.EventRegisterDto;
 import com.pyokemon.event.dto.EventResponseDto;
+import com.pyokemon.event.dto.TenantEventDetailResponseDTO;
 import com.pyokemon.event.dto.EventScheduleDto;
 import com.pyokemon.event.dto.EventUpdateDto;
 import com.pyokemon.event.dto.TenantEventListDto;
@@ -96,6 +97,15 @@ public class EventController {
     return ResponseDto.success(events,
         "Tenant events retrieved successfully for account_id: " + account_id);
   }
+
+  // 테넌트용 이벤트 상세조회 (가격 정보 포함)
+  @GetMapping("/tenant/{eventId}/detail")
+  public ResponseDto<TenantEventDetailResponseDTO> getTenantEventDetail(@PathVariable Long eventId) {
+    TenantEventDetailResponseDTO eventDetail = eventService.getTenantEventDetailByEventId(eventId);
+    return ResponseDto.success(eventDetail, "Tenant event detail retrieved successfully");
+  }
+
+
 
   // 일정 등록 (기존 공연에 일정 추가)
   @PostMapping("/{eventId}/schedules")

--- a/event/src/main/java/com/pyokemon/event/controller/EventController.java
+++ b/event/src/main/java/com/pyokemon/event/controller/EventController.java
@@ -14,13 +14,11 @@ import com.pyokemon.event.dto.EventItemResponseDTO;
 import com.pyokemon.event.dto.EventRegisterDto;
 import com.pyokemon.event.dto.EventResponseDto;
 import com.pyokemon.event.dto.EventScheduleDto;
-import com.pyokemon.event.dto.TenantEventListDto;
 import com.pyokemon.event.dto.EventUpdateDto;
+import com.pyokemon.event.dto.TenantEventListDto;
 import com.pyokemon.event.entity.Event;
 import com.pyokemon.event.service.EventScheduleService;
 import com.pyokemon.event.service.EventService;
-
-
 
 import lombok.RequiredArgsConstructor;
 
@@ -42,8 +40,7 @@ public class EventController {
 
   // 이벤트 수정
   @PutMapping("/{eventId}")
-  public ResponseDto<EventResponseDto> updateEvent(
-      @PathVariable Long eventId,
+  public ResponseDto<EventResponseDto> updateEvent(@PathVariable Long eventId,
       @Valid @RequestBody EventUpdateDto eventUpdateDto) {
     eventUpdateDto.setEventId(eventId);
     EventResponseDto updatedEvent = eventService.updateEvent(eventUpdateDto);
@@ -71,8 +68,8 @@ public class EventController {
   // 장르별 리스트 조회
   @GetMapping
   public List<EventItemResponseDTO> getConcertsByPage(
-      @RequestParam(defaultValue = "전체") String genre, @RequestParam(defaultValue = "1") int page,
-      @RequestParam(defaultValue = "9") int size) {
+      @RequestParam(defaultValue = "콘서트") String genre, @RequestParam(defaultValue = "1") int page,
+      @RequestParam(defaultValue = "8") int size) {
     int offset = (page - 1) * size;
     return eventScheduleService.getConcertsByPage(genre, offset, size);
   }
@@ -96,17 +93,18 @@ public class EventController {
   @GetMapping("/tenant")
   public ResponseDto<List<TenantEventListDto>> getTenantEventList(@RequestParam Long account_id) {
     List<TenantEventListDto> events = eventService.getTenantEventListByAccountId(account_id);
-    return ResponseDto.success(events, "Tenant events retrieved successfully for account_id: " + account_id);
+    return ResponseDto.success(events,
+        "Tenant events retrieved successfully for account_id: " + account_id);
   }
 
-                // 일정 등록 (기존 공연에 일정 추가)
-              @PostMapping("/{eventId}/schedules")
-              @ResponseStatus(HttpStatus.CREATED)
-              public ResponseDto<String> registerEventSchedule(
-                  @PathVariable Long eventId,
-                  @Valid @RequestBody EventScheduleDto eventScheduleDto) {
-                eventScheduleDto.setEventId(eventId);
-                eventScheduleService.registerEventSchedule(eventScheduleDto);
-                return ResponseDto.success("Event schedule registered successfully", "Event schedule registered successfully");
-              }
+  // 일정 등록 (기존 공연에 일정 추가)
+  @PostMapping("/{eventId}/schedules")
+  @ResponseStatus(HttpStatus.CREATED)
+  public ResponseDto<String> registerEventSchedule(@PathVariable Long eventId,
+      @Valid @RequestBody EventScheduleDto eventScheduleDto) {
+    eventScheduleDto.setEventId(eventId);
+    eventScheduleService.registerEventSchedule(eventScheduleDto);
+    return ResponseDto.success("Event schedule registered successfully",
+        "Event schedule registered successfully");
+  }
 }

--- a/event/src/main/java/com/pyokemon/event/controller/EventController.java
+++ b/event/src/main/java/com/pyokemon/event/controller/EventController.java
@@ -13,9 +13,14 @@ import com.pyokemon.event.dto.EventDetailResponseDTO;
 import com.pyokemon.event.dto.EventItemResponseDTO;
 import com.pyokemon.event.dto.EventRegisterDto;
 import com.pyokemon.event.dto.EventResponseDto;
+import com.pyokemon.event.dto.EventScheduleDto;
+import com.pyokemon.event.dto.TenantEventListDto;
+import com.pyokemon.event.dto.EventUpdateDto;
 import com.pyokemon.event.entity.Event;
 import com.pyokemon.event.service.EventScheduleService;
 import com.pyokemon.event.service.EventService;
+
+
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,6 +38,16 @@ public class EventController {
       @Valid @RequestBody EventRegisterDto eventRegisterDto) {
     EventResponseDto registeredEvent = eventService.registerEvent(eventRegisterDto);
     return ResponseDto.success(registeredEvent, "Event registered successfully");
+  }
+
+  // 이벤트 수정
+  @PutMapping("/{eventId}")
+  public ResponseDto<EventResponseDto> updateEvent(
+      @PathVariable Long eventId,
+      @Valid @RequestBody EventUpdateDto eventUpdateDto) {
+    eventUpdateDto.setEventId(eventId);
+    EventResponseDto updatedEvent = eventService.updateEvent(eventUpdateDto);
+    return ResponseDto.success(updatedEvent, "Event updated successfully");
   }
 
   // 오늘 오픈 티켓
@@ -70,4 +85,28 @@ public class EventController {
     int offset = (page - 1) * size;
     return eventScheduleService.getEventSearch(keyword, offset, size, genre);
   }
+  // 계정별 공연 목록 조회
+  @GetMapping("/my-events")
+  public ResponseDto<List<EventResponseDto>> getMyEvents(@RequestParam Long account_id) {
+    List<EventResponseDto> myEvents = eventService.getEventsByAccountId(account_id);
+    return ResponseDto.success(myEvents, "My events retrieved successfully");
+  }
+
+  // 테넌트별 공연 목록 조회 (테넌트 웹용)
+  @GetMapping("/tenant")
+  public ResponseDto<List<TenantEventListDto>> getTenantEventList(@RequestParam Long account_id) {
+    List<TenantEventListDto> events = eventService.getTenantEventListByAccountId(account_id);
+    return ResponseDto.success(events, "Tenant events retrieved successfully for account_id: " + account_id);
+  }
+
+                // 일정 등록 (기존 공연에 일정 추가)
+              @PostMapping("/{eventId}/schedules")
+              @ResponseStatus(HttpStatus.CREATED)
+              public ResponseDto<String> registerEventSchedule(
+                  @PathVariable Long eventId,
+                  @Valid @RequestBody EventScheduleDto eventScheduleDto) {
+                eventScheduleDto.setEventId(eventId);
+                eventScheduleService.registerEventSchedule(eventScheduleDto);
+                return ResponseDto.success("Event schedule registered successfully", "Event schedule registered successfully");
+              }
 }

--- a/event/src/main/java/com/pyokemon/event/controller/EventController.java
+++ b/event/src/main/java/com/pyokemon/event/controller/EventController.java
@@ -13,6 +13,7 @@ import com.pyokemon.event.dto.EventDetailResponseDTO;
 import com.pyokemon.event.dto.EventItemResponseDTO;
 import com.pyokemon.event.dto.EventRegisterDto;
 import com.pyokemon.event.dto.EventResponseDto;
+import com.pyokemon.event.dto.TenantBookingDetailResponseDTO;
 import com.pyokemon.event.dto.TenantEventDetailResponseDTO;
 import com.pyokemon.event.dto.EventScheduleDto;
 import com.pyokemon.event.dto.EventUpdateDto;
@@ -69,8 +70,8 @@ public class EventController {
   // 장르별 리스트 조회
   @GetMapping
   public List<EventItemResponseDTO> getConcertsByPage(
-      @RequestParam(defaultValue = "콘서트") String genre, @RequestParam(defaultValue = "1") int page,
-      @RequestParam(defaultValue = "8") int size) {
+      @RequestParam(defaultValue = "전체") String genre, @RequestParam(defaultValue = "1") int page,
+      @RequestParam(defaultValue = "9") int size) {
     int offset = (page - 1) * size;
     return eventScheduleService.getConcertsByPage(genre, offset, size);
   }
@@ -103,6 +104,13 @@ public class EventController {
   public ResponseDto<TenantEventDetailResponseDTO> getTenantEventDetail(@PathVariable Long eventId) {
     TenantEventDetailResponseDTO eventDetail = eventService.getTenantEventDetailByEventId(eventId);
     return ResponseDto.success(eventDetail, "Tenant event detail retrieved successfully");
+  }
+
+  // 테넌트용 예매 현황 조회 (event_schedule_id 기반)
+  @GetMapping("/tenant/booking/{eventScheduleId}/detail")
+  public ResponseDto<TenantBookingDetailResponseDTO> getTenantBookingDetail(@PathVariable Long eventScheduleId) {
+    TenantBookingDetailResponseDTO bookingDetail = eventService.getTenantBookingDetailByEventScheduleId(eventScheduleId);
+    return ResponseDto.success(bookingDetail, "Tenant booking detail retrieved successfully");
   }
 
 

--- a/event/src/main/java/com/pyokemon/event/dto/EventDetailResponseDTO.java
+++ b/event/src/main/java/com/pyokemon/event/dto/EventDetailResponseDTO.java
@@ -2,11 +2,15 @@ package com.pyokemon.event.dto;
 
 import java.time.LocalDateTime;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class EventDetailResponseDTO {
   // event
   private Long eventId;

--- a/event/src/main/java/com/pyokemon/event/dto/EventItemResponseDTO.java
+++ b/event/src/main/java/com/pyokemon/event/dto/EventItemResponseDTO.java
@@ -4,9 +4,9 @@ import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
 
 @Data
 @NoArgsConstructor

--- a/event/src/main/java/com/pyokemon/event/dto/EventItemResponseDTO.java
+++ b/event/src/main/java/com/pyokemon/event/dto/EventItemResponseDTO.java
@@ -6,9 +6,11 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
 public class EventItemResponseDTO {
   private Long eventScheduleId;
   private Long eventId;

--- a/event/src/main/java/com/pyokemon/event/dto/EventRegisterDto.java
+++ b/event/src/main/java/com/pyokemon/event/dto/EventRegisterDto.java
@@ -26,8 +26,8 @@ public class EventRegisterDto {
 
   private Long eventId;
 
-  @NotNull(message = "Tenant ID is required")
-  private Long tenantId;
+  // @NotNull(message = "Account ID is required") // 임시로 주석 처리 (account 서비스 완료 전까지)
+  private Long accountId;
 
   @NotBlank(message = "Title is required")
   @Size(max = 100, message = "Title must be less than 100 characters")

--- a/event/src/main/java/com/pyokemon/event/dto/EventScheduleUpdateDto.java
+++ b/event/src/main/java/com/pyokemon/event/dto/EventScheduleUpdateDto.java
@@ -20,19 +20,19 @@ import lombok.Setter;
 @AllArgsConstructor
 public class EventScheduleUpdateDto {
 
-    private Long eventScheduleId;
+  private Long eventScheduleId;
 
-    @NotNull(message = "Venue ID is required")
-    private Long venueId;
+  @NotNull(message = "Venue ID is required")
+  private Long venueId;
 
-    @NotNull(message = "Ticket open date is required")
-    @Future(message = "Ticket open date must be in the future")
-    private LocalDateTime ticketOpenAt;
+  @NotNull(message = "Ticket open date is required")
+  @Future(message = "Ticket open date must be in the future")
+  private LocalDateTime ticketOpenAt;
 
-    @NotNull(message = "Event date is required")
-    @Future(message = "Event date must be in the future")
-    private LocalDateTime eventDate;
+  @NotNull(message = "Event date is required")
+  @Future(message = "Event date must be in the future")
+  private LocalDateTime eventDate;
 
-    @Valid
-    private List<PriceUpdateDto> prices;
-} 
+  @Valid
+  private List<PriceUpdateDto> prices;
+}

--- a/event/src/main/java/com/pyokemon/event/dto/EventScheduleUpdateDto.java
+++ b/event/src/main/java/com/pyokemon/event/dto/EventScheduleUpdateDto.java
@@ -1,0 +1,38 @@
+package com.pyokemon.event.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotNull;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventScheduleUpdateDto {
+
+    private Long eventScheduleId;
+
+    @NotNull(message = "Venue ID is required")
+    private Long venueId;
+
+    @NotNull(message = "Ticket open date is required")
+    @Future(message = "Ticket open date must be in the future")
+    private LocalDateTime ticketOpenAt;
+
+    @NotNull(message = "Event date is required")
+    @Future(message = "Event date must be in the future")
+    private LocalDateTime eventDate;
+
+    @Valid
+    private List<PriceUpdateDto> prices;
+} 

--- a/event/src/main/java/com/pyokemon/event/dto/EventUpdateDto.java
+++ b/event/src/main/java/com/pyokemon/event/dto/EventUpdateDto.java
@@ -1,0 +1,50 @@
+package com.pyokemon.event.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import com.pyokemon.event.entity.Event.EventStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventUpdateDto {
+
+    @NotNull(message = "Event ID is required")
+    private Long eventId;
+
+    @NotBlank(message = "Title is required")
+    @Size(max = 100, message = "Title must be less than 100 characters")
+    private String title;
+
+    @NotNull(message = "Age limit is required")
+    @Min(value = 0, message = "Age limit cannot be negative")
+    private Long ageLimit;
+
+    @NotBlank(message = "Description is required")
+    private String description;
+
+    @NotBlank(message = "Genre is required")
+    private String genre;
+
+    private String thumbnailUrl;
+
+    private EventStatus status;
+
+    @Valid
+    private List<EventScheduleUpdateDto> schedules;
+} 

--- a/event/src/main/java/com/pyokemon/event/dto/EventUpdateDto.java
+++ b/event/src/main/java/com/pyokemon/event/dto/EventUpdateDto.java
@@ -24,27 +24,27 @@ import lombok.Setter;
 @AllArgsConstructor
 public class EventUpdateDto {
 
-    @NotNull(message = "Event ID is required")
-    private Long eventId;
+  @NotNull(message = "Event ID is required")
+  private Long eventId;
 
-    @NotBlank(message = "Title is required")
-    @Size(max = 100, message = "Title must be less than 100 characters")
-    private String title;
+  @NotBlank(message = "Title is required")
+  @Size(max = 100, message = "Title must be less than 100 characters")
+  private String title;
 
-    @NotNull(message = "Age limit is required")
-    @Min(value = 0, message = "Age limit cannot be negative")
-    private Long ageLimit;
+  @NotNull(message = "Age limit is required")
+  @Min(value = 0, message = "Age limit cannot be negative")
+  private Long ageLimit;
 
-    @NotBlank(message = "Description is required")
-    private String description;
+  @NotBlank(message = "Description is required")
+  private String description;
 
-    @NotBlank(message = "Genre is required")
-    private String genre;
+  @NotBlank(message = "Genre is required")
+  private String genre;
 
-    private String thumbnailUrl;
+  private String thumbnailUrl;
 
-    private EventStatus status;
+  private EventStatus status;
 
-    @Valid
-    private List<EventScheduleUpdateDto> schedules;
-} 
+  @Valid
+  private List<EventScheduleUpdateDto> schedules;
+}

--- a/event/src/main/java/com/pyokemon/event/dto/PriceUpdateDto.java
+++ b/event/src/main/java/com/pyokemon/event/dto/PriceUpdateDto.java
@@ -1,0 +1,27 @@
+package com.pyokemon.event.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PriceUpdateDto {
+
+    private Long priceId;
+
+    @NotNull(message = "Seat class ID is required")
+    private Long seatClassId;
+
+    @NotNull(message = "Price is required")
+    @Min(value = 0, message = "Price cannot be negative")
+    private Integer price;
+} 

--- a/event/src/main/java/com/pyokemon/event/dto/PriceUpdateDto.java
+++ b/event/src/main/java/com/pyokemon/event/dto/PriceUpdateDto.java
@@ -16,12 +16,12 @@ import lombok.Setter;
 @AllArgsConstructor
 public class PriceUpdateDto {
 
-    private Long priceId;
+  private Long priceId;
 
-    @NotNull(message = "Seat class ID is required")
-    private Long seatClassId;
+  @NotNull(message = "Seat class ID is required")
+  private Long seatClassId;
 
-    @NotNull(message = "Price is required")
-    @Min(value = 0, message = "Price cannot be negative")
-    private Integer price;
-} 
+  @NotNull(message = "Price is required")
+  @Min(value = 0, message = "Price cannot be negative")
+  private Integer price;
+}

--- a/event/src/main/java/com/pyokemon/event/dto/TenantBookingDetailResponseDTO.java
+++ b/event/src/main/java/com/pyokemon/event/dto/TenantBookingDetailResponseDTO.java
@@ -1,0 +1,46 @@
+package com.pyokemon.event.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TenantBookingDetailResponseDTO {
+    // event 정보
+    private Long eventId;
+    private String title;
+    private String genre;
+    private String status;
+
+    // event schedule 정보
+    private Long eventScheduleId;
+    private LocalDateTime ticketOpenAt;
+    private LocalDateTime eventDate;
+
+    // venue 정보
+    private String venueName;
+
+    // 예매 현황 정보
+    private List<BookingStatusInfo> bookingStatus;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BookingStatusInfo {
+        private Long seatClassId;
+        private String className;
+        private Integer totalSeats;
+        private Integer bookedSeats;
+        private Integer availableSeats;
+        private Integer price;
+        private Double bookingRate; // 예매율 (예매된 좌석 / 전체 좌석 * 100)
+    }
+} 

--- a/event/src/main/java/com/pyokemon/event/dto/TenantEventDetailResponseDTO.java
+++ b/event/src/main/java/com/pyokemon/event/dto/TenantEventDetailResponseDTO.java
@@ -1,0 +1,46 @@
+package com.pyokemon.event.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TenantEventDetailResponseDTO {
+    // event 정보
+    private Long eventId;
+    private String title;
+    private Long ageLimit;
+    private String description;
+    private String genre;
+    private String thumbnailUrl;
+    private String status;
+
+    // event schedule 정보
+    private Long eventScheduleId;
+    private LocalDateTime ticketOpenAt;
+    private LocalDateTime eventDate;
+
+    // venue 정보
+    private String venueName;
+
+    // 가격 정보
+    private List<PriceInfo> prices;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PriceInfo {
+        private Long priceId;
+        private Long seatClassId;
+        private String className;
+        private Integer price;
+    }
+} 

--- a/event/src/main/java/com/pyokemon/event/dto/TenantEventListDto.java
+++ b/event/src/main/java/com/pyokemon/event/dto/TenantEventListDto.java
@@ -22,4 +22,4 @@ public class TenantEventListDto {
   private LocalDateTime eventDate;
   private String venueName;
   private EventStatus status;
-} 
+}

--- a/event/src/main/java/com/pyokemon/event/dto/TenantEventListDto.java
+++ b/event/src/main/java/com/pyokemon/event/dto/TenantEventListDto.java
@@ -17,6 +17,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class TenantEventListDto {
   private Long eventId;
+  private Long eventScheduleId;
   private String thumbnailUrl;
   private String title;
   private LocalDateTime eventDate;

--- a/event/src/main/java/com/pyokemon/event/dto/TenantEventListDto.java
+++ b/event/src/main/java/com/pyokemon/event/dto/TenantEventListDto.java
@@ -15,15 +15,11 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class EventResponseDto {
+public class TenantEventListDto {
   private Long eventId;
-  private Long accountId;
-  private String title;
-  private Long ageLimit;
-  private String description;
-  private String genre;
   private String thumbnailUrl;
+  private String title;
+  private LocalDateTime eventDate;
+  private String venueName;
   private EventStatus status;
-  private LocalDateTime createdAt;
-  private LocalDateTime updatedAt;
-}
+} 

--- a/event/src/main/java/com/pyokemon/event/entity/Event.java
+++ b/event/src/main/java/com/pyokemon/event/entity/Event.java
@@ -16,7 +16,7 @@ import lombok.Setter;
 public class Event {
 
   private Long eventId;
-  private Long tenantId;
+  private Long accountId;
   private String title;
   private Long ageLimit;
   private String description;

--- a/event/src/main/java/com/pyokemon/event/mapper/EventMapper.java
+++ b/event/src/main/java/com/pyokemon/event/mapper/EventMapper.java
@@ -17,7 +17,7 @@ public class EventMapper {
 
   public Event toEntity(EventRegisterDto dto) {
     dto.setStatus(Event.EventStatus.PENDING);
-    return Event.builder().tenantId(dto.getTenantId()).title(dto.getTitle())
+    return Event.builder().accountId(dto.getAccountId()).title(dto.getTitle())
         .ageLimit(dto.getAgeLimit()).description(dto.getDescription()).genre(dto.getGenre())
         .thumbnailUrl(dto.getThumbnailUrl()).status(dto.getStatus()).createdAt(LocalDateTime.now())
         .updatedAt(LocalDateTime.now()).build();
@@ -36,9 +36,17 @@ public class EventMapper {
   }
 
   public EventResponseDto toResponseDto(Event event) {
-    return EventResponseDto.builder().eventId(event.getEventId()).tenantId(event.getTenantId())
-        .title(event.getTitle()).ageLimit(event.getAgeLimit()).description(event.getDescription())
-        .genre(event.getGenre()).thumbnailUrl(event.getThumbnailUrl()).status(event.getStatus())
-        .createdAt(event.getCreatedAt()).updatedAt(event.getUpdatedAt()).build();
+    EventResponseDto responseDto = new EventResponseDto();
+    responseDto.setEventId(event.getEventId());
+    responseDto.setAccountId(event.getAccountId());
+    responseDto.setTitle(event.getTitle());
+    responseDto.setAgeLimit(event.getAgeLimit());
+    responseDto.setDescription(event.getDescription());
+    responseDto.setGenre(event.getGenre());
+    responseDto.setThumbnailUrl(event.getThumbnailUrl());
+    responseDto.setStatus(event.getStatus());
+    responseDto.setCreatedAt(event.getCreatedAt());
+    responseDto.setUpdatedAt(event.getUpdatedAt());
+    return responseDto;
   }
 }

--- a/event/src/main/java/com/pyokemon/event/repository/EventRepository.java
+++ b/event/src/main/java/com/pyokemon/event/repository/EventRepository.java
@@ -11,9 +11,9 @@ import com.pyokemon.event.entity.Event;
 @Mapper
 public interface EventRepository {
   List<Event> findByTenantId(Long tenantId);
-  
+
   List<Event> findByAccountId(Long accountId);
-  
+
   List<TenantEventListDto> findTenantEventListByAccountId(Long accountId);
 
   List<Event> findByStatus(Event.EventStatus status);

--- a/event/src/main/java/com/pyokemon/event/repository/EventRepository.java
+++ b/event/src/main/java/com/pyokemon/event/repository/EventRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.pyokemon.event.dto.EventDetailResponseDTO;
+import com.pyokemon.event.dto.TenantEventDetailResponseDTO;
 import com.pyokemon.event.dto.TenantEventListDto;
 import com.pyokemon.event.entity.Event;
 
@@ -27,6 +28,8 @@ public interface EventRepository {
   int save(Event event);
 
   EventDetailResponseDTO findEventDetailByEventId(Long eventId);
+
+  TenantEventDetailResponseDTO findTenantEventDetailByEventId(Long eventId);
 
   Event findById(Long eventId);
 

--- a/event/src/main/java/com/pyokemon/event/repository/EventRepository.java
+++ b/event/src/main/java/com/pyokemon/event/repository/EventRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.pyokemon.event.dto.EventDetailResponseDTO;
+import com.pyokemon.event.dto.TenantBookingDetailResponseDTO;
 import com.pyokemon.event.dto.TenantEventDetailResponseDTO;
 import com.pyokemon.event.dto.TenantEventListDto;
 import com.pyokemon.event.entity.Event;
@@ -25,7 +26,7 @@ public interface EventRepository {
 
   List<Event> findByAgeLimit(Long ageLimit);
 
-  int save(Event event);
+  Long save(Event event);
 
   EventDetailResponseDTO findEventDetailByEventId(Long eventId);
 
@@ -34,4 +35,6 @@ public interface EventRepository {
   Event findById(Long eventId);
 
   int updateEvent(Event event);
+
+  TenantBookingDetailResponseDTO findTenantBookingDetailByEventScheduleId(Long eventScheduleId);
 }

--- a/event/src/main/java/com/pyokemon/event/repository/EventRepository.java
+++ b/event/src/main/java/com/pyokemon/event/repository/EventRepository.java
@@ -5,11 +5,16 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.pyokemon.event.dto.EventDetailResponseDTO;
+import com.pyokemon.event.dto.TenantEventListDto;
 import com.pyokemon.event.entity.Event;
 
 @Mapper
 public interface EventRepository {
   List<Event> findByTenantId(Long tenantId);
+  
+  List<Event> findByAccountId(Long accountId);
+  
+  List<TenantEventListDto> findTenantEventListByAccountId(Long accountId);
 
   List<Event> findByStatus(Event.EventStatus status);
 
@@ -19,7 +24,11 @@ public interface EventRepository {
 
   List<Event> findByAgeLimit(Long ageLimit);
 
-  Long save(Event event);
+  int save(Event event);
 
   EventDetailResponseDTO findEventDetailByEventId(Long eventId);
+
+  Event findById(Long eventId);
+
+  int updateEvent(Event event);
 }

--- a/event/src/main/java/com/pyokemon/event/repository/EventScheduleRepository.java
+++ b/event/src/main/java/com/pyokemon/event/repository/EventScheduleRepository.java
@@ -31,7 +31,5 @@ public interface EventScheduleRepository {
 
   int getSearchTotalCount(@Param("keyword") String keyword, @Param("genre") String genre);
   int updateEventSchedule(EventSchedule eventSchedule);
-
-  // For debugging
-
+  
 }

--- a/event/src/main/java/com/pyokemon/event/repository/EventScheduleRepository.java
+++ b/event/src/main/java/com/pyokemon/event/repository/EventScheduleRepository.java
@@ -19,7 +19,7 @@ public interface EventScheduleRepository {
 
   Optional<EventSchedule> findById(Long id);
 
-  Long save(EventSchedule eventSchedule);
+  int save(EventSchedule eventSchedule);
 
   List<EventItemResponseDTO> selectEventList(@Param("genre") String genre,
       @Param("limit") int limit, @Param("offset") int offset);
@@ -30,5 +30,8 @@ public interface EventScheduleRepository {
       @Param("limit") int limit, @Param("offset") int offset, @Param("genre") String genre);
 
   int getSearchTotalCount(@Param("keyword") String keyword, @Param("genre") String genre);
+  int updateEventSchedule(EventSchedule eventSchedule);
+
+  // For debugging
 
 }

--- a/event/src/main/java/com/pyokemon/event/repository/EventScheduleRepository.java
+++ b/event/src/main/java/com/pyokemon/event/repository/EventScheduleRepository.java
@@ -19,7 +19,7 @@ public interface EventScheduleRepository {
 
   Optional<EventSchedule> findById(Long id);
 
-  int save(EventSchedule eventSchedule);
+  Long save(EventSchedule eventSchedule);
 
   List<EventItemResponseDTO> selectEventList(@Param("genre") String genre,
       @Param("limit") int limit, @Param("offset") int offset);

--- a/event/src/main/java/com/pyokemon/event/repository/PriceRepository.java
+++ b/event/src/main/java/com/pyokemon/event/repository/PriceRepository.java
@@ -8,12 +8,12 @@ import com.pyokemon.event.entity.Price;
 
 @Mapper
 public interface PriceRepository {
-    
-    Long save(Price price);
-    
-    int updatePrice(Price price);
-    
-    int deletePrice(Long priceId);
-    
-    List<Price> findByEventScheduleId(Long eventScheduleId);
+
+  Long save(Price price);
+
+  int updatePrice(Price price);
+
+  int deletePrice(Long priceId);
+
+  List<Price> findByEventScheduleId(Long eventScheduleId);
 }

--- a/event/src/main/java/com/pyokemon/event/repository/PriceRepository.java
+++ b/event/src/main/java/com/pyokemon/event/repository/PriceRepository.java
@@ -1,6 +1,5 @@
 package com.pyokemon.event.repository;
 
-
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
@@ -9,8 +8,12 @@ import com.pyokemon.event.entity.Price;
 
 @Mapper
 public interface PriceRepository {
-  List<Price> findByEventScheduleId(Long eventScheduleId);
-
-  Long save(Price price);
-
+    
+    Long save(Price price);
+    
+    int updatePrice(Price price);
+    
+    int deletePrice(Long priceId);
+    
+    List<Price> findByEventScheduleId(Long eventScheduleId);
 }

--- a/event/src/main/java/com/pyokemon/event/service/EventScheduleService.java
+++ b/event/src/main/java/com/pyokemon/event/service/EventScheduleService.java
@@ -5,7 +5,14 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.pyokemon.event.dto.EventItemResponseDTO;
+import com.pyokemon.event.dto.EventScheduleDto;
+import com.pyokemon.event.entity.EventSchedule;
 import com.pyokemon.event.repository.EventScheduleRepository;
+import com.pyokemon.event.repository.PriceRepository;
+import com.pyokemon.event.entity.Price;
+import com.pyokemon.event.dto.PriceDto;
+
+import java.time.LocalDateTime;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class EventScheduleService {
 
   private final EventScheduleRepository eventScheduleRepository;
+  private final PriceRepository priceRepository;
 
   public List<EventItemResponseDTO> getTodayOpenedTickets() {
     return eventScheduleRepository.selectTodayOpenedTickets();
@@ -46,6 +54,44 @@ public class EventScheduleService {
     }
 
     return events;
+  }
+  
+  public void registerEventSchedule(EventScheduleDto eventScheduleDto) {
+    // Create and save event schedule
+    EventSchedule eventSchedule = mapToEventSchedule(eventScheduleDto);
+    eventScheduleRepository.save(eventSchedule);
+    Long eventScheduleId = eventSchedule.getEventScheduleId();
+
+    // Save prices if present
+    if (eventScheduleDto.getPrices() != null) {
+      for (PriceDto priceDto : eventScheduleDto.getPrices()) {
+        priceDto.setEventScheduleId(eventScheduleId);
+        Price price = mapToPrice(priceDto);
+        priceRepository.save(price);
+      }
+    }
+  }
+
+  private EventSchedule mapToEventSchedule(EventScheduleDto dto) {
+    EventSchedule eventSchedule = EventSchedule.builder()
+        .eventId(dto.getEventId())
+        .venueId(dto.getVenueId())
+        .ticketOpenAt(dto.getTicketOpenAt())
+        .eventDate(dto.getEventDate())
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+    return eventSchedule;
+  }
+
+  private Price mapToPrice(PriceDto dto) {
+    return Price.builder()
+        .eventScheduleId(dto.getEventScheduleId())
+        .seatClassId(dto.getSeatClassId())
+        .price(dto.getPrice())
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
   }
 
 }

--- a/event/src/main/java/com/pyokemon/event/service/EventScheduleService.java
+++ b/event/src/main/java/com/pyokemon/event/service/EventScheduleService.java
@@ -1,18 +1,17 @@
 package com.pyokemon.event.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 
 import com.pyokemon.event.dto.EventItemResponseDTO;
 import com.pyokemon.event.dto.EventScheduleDto;
+import com.pyokemon.event.dto.PriceDto;
 import com.pyokemon.event.entity.EventSchedule;
+import com.pyokemon.event.entity.Price;
 import com.pyokemon.event.repository.EventScheduleRepository;
 import com.pyokemon.event.repository.PriceRepository;
-import com.pyokemon.event.entity.Price;
-import com.pyokemon.event.dto.PriceDto;
-
-import java.time.LocalDateTime;
 
 import lombok.RequiredArgsConstructor;
 
@@ -73,25 +72,16 @@ public class EventScheduleService {
   }
 
   private EventSchedule mapToEventSchedule(EventScheduleDto dto) {
-    EventSchedule eventSchedule = EventSchedule.builder()
-        .eventId(dto.getEventId())
-        .venueId(dto.getVenueId())
-        .ticketOpenAt(dto.getTicketOpenAt())
-        .eventDate(dto.getEventDate())
-        .createdAt(LocalDateTime.now())
-        .updatedAt(LocalDateTime.now())
-        .build();
+    EventSchedule eventSchedule = EventSchedule.builder().eventId(dto.getEventId())
+        .venueId(dto.getVenueId()).ticketOpenAt(dto.getTicketOpenAt()).eventDate(dto.getEventDate())
+        .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).build();
     return eventSchedule;
   }
 
   private Price mapToPrice(PriceDto dto) {
-    return Price.builder()
-        .eventScheduleId(dto.getEventScheduleId())
-        .seatClassId(dto.getSeatClassId())
-        .price(dto.getPrice())
-        .createdAt(LocalDateTime.now())
-        .updatedAt(LocalDateTime.now())
-        .build();
+    return Price.builder().eventScheduleId(dto.getEventScheduleId())
+        .seatClassId(dto.getSeatClassId()).price(dto.getPrice()).createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now()).build();
   }
 
 }

--- a/event/src/main/java/com/pyokemon/event/service/EventService.java
+++ b/event/src/main/java/com/pyokemon/event/service/EventService.java
@@ -1,6 +1,7 @@
 package com.pyokemon.event.service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,13 +11,11 @@ import com.pyokemon.event.dto.EventDetailResponseDTO;
 import com.pyokemon.event.dto.EventRegisterDto;
 import com.pyokemon.event.dto.EventResponseDto;
 import com.pyokemon.event.dto.EventScheduleDto;
-import com.pyokemon.event.dto.PriceDto;
-import com.pyokemon.event.dto.EventUpdateDto;
 import com.pyokemon.event.dto.EventScheduleUpdateDto;
+import com.pyokemon.event.dto.EventUpdateDto;
+import com.pyokemon.event.dto.PriceDto;
 import com.pyokemon.event.dto.PriceUpdateDto;
 import com.pyokemon.event.dto.TenantEventListDto;
-
-import java.util.List;
 import com.pyokemon.event.entity.Event;
 import com.pyokemon.event.entity.EventSchedule;
 import com.pyokemon.event.entity.Price;
@@ -44,9 +43,7 @@ public class EventService {
 
   public List<EventResponseDto> getEventsByAccountId(Long accountId) {
     List<Event> events = eventRepository.findByAccountId(accountId);
-    return events.stream()
-        .map(this::mapToEventResponseDto)
-        .toList();
+    return events.stream().map(this::mapToEventResponseDto).toList();
   }
 
   public List<TenantEventListDto> getTenantEventListByAccountId(Long accountId) {
@@ -58,14 +55,16 @@ public class EventService {
     // 기존 이벤트 존재 여부 확인
     Event existingEvent = findEventById(eventUpdateDto.getEventId());
     if (existingEvent == null) {
-      throw new BusinessException("Event not found with id: " + eventUpdateDto.getEventId(), "EVENT_NOT_FOUND");
+      throw new BusinessException("Event not found with id: " + eventUpdateDto.getEventId(),
+          "EVENT_NOT_FOUND");
     }
 
     // 공연장 유효성 검사
     if (eventUpdateDto.getSchedules() != null && !eventUpdateDto.getSchedules().isEmpty()) {
       for (EventScheduleUpdateDto scheduleDto : eventUpdateDto.getSchedules()) {
         if (!validateVenueExists(scheduleDto.getVenueId())) {
-          throw new BusinessException("Venue not found with id: " + scheduleDto.getVenueId(), "VENUE_NOT_FOUND");
+          throw new BusinessException("Venue not found with id: " + scheduleDto.getVenueId(),
+              "VENUE_NOT_FOUND");
         }
       }
     }
@@ -95,7 +94,7 @@ public class EventService {
       event.setStatus(updateDto.getStatus());
     }
     event.setUpdatedAt(LocalDateTime.now());
-    
+
     // 이벤트 정보 저장
     eventRepository.updateEvent(event);
   }
@@ -115,7 +114,7 @@ public class EventService {
   private void updateExistingSchedule(EventScheduleUpdateDto scheduleDto) {
     EventSchedule schedule = mapToEventScheduleForUpdate(scheduleDto);
     eventScheduleRepository.updateEventSchedule(schedule);
-    
+
     // 가격 정보 업데이트
     if (scheduleDto.getPrices() != null) {
       updateSchedulePrices(scheduleDto.getEventScheduleId(), scheduleDto.getPrices());
@@ -126,10 +125,10 @@ public class EventService {
     scheduleDto.setEventScheduleId(null); // 새 스케줄임을 명시
     EventSchedule newSchedule = mapToEventScheduleForUpdate(scheduleDto);
     newSchedule.setEventId(eventId);
-    
+
     eventScheduleRepository.save(newSchedule);
     Long newScheduleId = newSchedule.getEventScheduleId();
-    
+
     // 새 가격 정보 추가
     if (scheduleDto.getPrices() != null) {
       for (PriceUpdateDto priceDto : scheduleDto.getPrices()) {
@@ -157,22 +156,14 @@ public class EventService {
   }
 
   private EventSchedule mapToEventScheduleForUpdate(EventScheduleUpdateDto dto) {
-    return EventSchedule.builder()
-        .eventScheduleId(dto.getEventScheduleId())
-        .venueId(dto.getVenueId())
-        .ticketOpenAt(dto.getTicketOpenAt())
-        .eventDate(dto.getEventDate())
-        .updatedAt(LocalDateTime.now())
-        .build();
+    return EventSchedule.builder().eventScheduleId(dto.getEventScheduleId())
+        .venueId(dto.getVenueId()).ticketOpenAt(dto.getTicketOpenAt()).eventDate(dto.getEventDate())
+        .updatedAt(LocalDateTime.now()).build();
   }
 
   private Price mapToPriceForUpdate(PriceUpdateDto dto) {
-    return Price.builder()
-        .priceId(dto.getPriceId())
-        .seatClassId(dto.getSeatClassId())
-        .price(dto.getPrice())
-        .updatedAt(LocalDateTime.now())
-        .build();
+    return Price.builder().priceId(dto.getPriceId()).seatClassId(dto.getSeatClassId())
+        .price(dto.getPrice()).updatedAt(LocalDateTime.now()).build();
   }
 
   @Transactional
@@ -204,17 +195,13 @@ public class EventService {
       for (EventScheduleDto scheduleDto : eventRegisterDto.getSchedules()) {
         // 새로운 eventId를 설정
         scheduleDto.setEventId(eventId);
-        
+
         // EventSchedule 생성 시 eventId를 직접 전달
-        EventSchedule eventSchedule = EventSchedule.builder()
-            .eventId(eventId)  // 직접 eventId 설정
-            .venueId(scheduleDto.getVenueId())
-            .ticketOpenAt(scheduleDto.getTicketOpenAt())
-            .eventDate(scheduleDto.getEventDate())
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
-            .build();
-            
+        EventSchedule eventSchedule = EventSchedule.builder().eventId(eventId) // 직접 eventId 설정
+            .venueId(scheduleDto.getVenueId()).ticketOpenAt(scheduleDto.getTicketOpenAt())
+            .eventDate(scheduleDto.getEventDate()).createdAt(LocalDateTime.now())
+            .updatedAt(LocalDateTime.now()).build();
+
         Long eventScheduleId = saveEventSchedule(eventSchedule);
 
         // Save prices if present
@@ -243,11 +230,13 @@ public class EventService {
   }
 
   private EventSchedule mapToEventSchedule(EventScheduleDto dto, Long eventId) {
-    System.out.println("mapToEventSchedule - dto.getEventId(): " + dto.getEventId() + ", passed eventId: " + eventId);
+    System.out.println("mapToEventSchedule - dto.getEventId(): " + dto.getEventId()
+        + ", passed eventId: " + eventId);
     EventSchedule eventSchedule = EventSchedule.builder().eventId(eventId).venueId(dto.getVenueId())
         .ticketOpenAt(dto.getTicketOpenAt()).eventDate(dto.getEventDate())
         .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).build();
-    System.out.println("mapToEventSchedule - built eventSchedule.eventId: " + eventSchedule.getEventId());
+    System.out
+        .println("mapToEventSchedule - built eventSchedule.eventId: " + eventSchedule.getEventId());
     return eventSchedule;
   }
 

--- a/event/src/main/java/com/pyokemon/event/service/EventService.java
+++ b/event/src/main/java/com/pyokemon/event/service/EventService.java
@@ -10,6 +10,7 @@ import com.pyokemon.common.exception.BusinessException;
 import com.pyokemon.event.dto.EventDetailResponseDTO;
 import com.pyokemon.event.dto.EventRegisterDto;
 import com.pyokemon.event.dto.EventResponseDto;
+import com.pyokemon.event.dto.TenantBookingDetailResponseDTO;
 import com.pyokemon.event.dto.TenantEventDetailResponseDTO;
 import com.pyokemon.event.dto.EventScheduleDto;
 import com.pyokemon.event.dto.EventScheduleUpdateDto;
@@ -44,6 +45,10 @@ public class EventService {
 
   public TenantEventDetailResponseDTO getTenantEventDetailByEventId(Long eventId) {
     return eventRepository.findTenantEventDetailByEventId(eventId);
+  }
+
+  public TenantBookingDetailResponseDTO getTenantBookingDetailByEventScheduleId(Long eventScheduleId) {
+    return eventRepository.findTenantBookingDetailByEventScheduleId(eventScheduleId);
   }
 
   public List<EventResponseDto> getEventsByAccountId(Long accountId) {

--- a/event/src/main/java/com/pyokemon/event/service/EventService.java
+++ b/event/src/main/java/com/pyokemon/event/service/EventService.java
@@ -10,6 +10,7 @@ import com.pyokemon.common.exception.BusinessException;
 import com.pyokemon.event.dto.EventDetailResponseDTO;
 import com.pyokemon.event.dto.EventRegisterDto;
 import com.pyokemon.event.dto.EventResponseDto;
+import com.pyokemon.event.dto.TenantEventDetailResponseDTO;
 import com.pyokemon.event.dto.EventScheduleDto;
 import com.pyokemon.event.dto.EventScheduleUpdateDto;
 import com.pyokemon.event.dto.EventUpdateDto;
@@ -39,6 +40,10 @@ public class EventService {
 
   public EventDetailResponseDTO getEventDetailByEventId(Long eventId) {
     return eventRepository.findEventDetailByEventId(eventId);
+  }
+
+  public TenantEventDetailResponseDTO getTenantEventDetailByEventId(Long eventId) {
+    return eventRepository.findTenantEventDetailByEventId(eventId);
   }
 
   public List<EventResponseDto> getEventsByAccountId(Long accountId) {

--- a/event/src/main/java/com/pyokemon/event/service/EventService.java
+++ b/event/src/main/java/com/pyokemon/event/service/EventService.java
@@ -11,6 +11,12 @@ import com.pyokemon.event.dto.EventRegisterDto;
 import com.pyokemon.event.dto.EventResponseDto;
 import com.pyokemon.event.dto.EventScheduleDto;
 import com.pyokemon.event.dto.PriceDto;
+import com.pyokemon.event.dto.EventUpdateDto;
+import com.pyokemon.event.dto.EventScheduleUpdateDto;
+import com.pyokemon.event.dto.PriceUpdateDto;
+import com.pyokemon.event.dto.TenantEventListDto;
+
+import java.util.List;
 import com.pyokemon.event.entity.Event;
 import com.pyokemon.event.entity.EventSchedule;
 import com.pyokemon.event.entity.Price;
@@ -36,6 +42,139 @@ public class EventService {
     return eventRepository.findEventDetailByEventId(eventId);
   }
 
+  public List<EventResponseDto> getEventsByAccountId(Long accountId) {
+    List<Event> events = eventRepository.findByAccountId(accountId);
+    return events.stream()
+        .map(this::mapToEventResponseDto)
+        .toList();
+  }
+
+  public List<TenantEventListDto> getTenantEventListByAccountId(Long accountId) {
+    return eventRepository.findTenantEventListByAccountId(accountId);
+  }
+
+  @Transactional
+  public EventResponseDto updateEvent(EventUpdateDto eventUpdateDto) {
+    // 기존 이벤트 존재 여부 확인
+    Event existingEvent = findEventById(eventUpdateDto.getEventId());
+    if (existingEvent == null) {
+      throw new BusinessException("Event not found with id: " + eventUpdateDto.getEventId(), "EVENT_NOT_FOUND");
+    }
+
+    // 공연장 유효성 검사
+    if (eventUpdateDto.getSchedules() != null && !eventUpdateDto.getSchedules().isEmpty()) {
+      for (EventScheduleUpdateDto scheduleDto : eventUpdateDto.getSchedules()) {
+        if (!validateVenueExists(scheduleDto.getVenueId())) {
+          throw new BusinessException("Venue not found with id: " + scheduleDto.getVenueId(), "VENUE_NOT_FOUND");
+        }
+      }
+    }
+
+    // 이벤트 정보 업데이트
+    updateEventInfo(existingEvent, eventUpdateDto);
+
+    // 스케줄 및 가격 정보 업데이트
+    if (eventUpdateDto.getSchedules() != null) {
+      updateEventSchedules(eventUpdateDto.getEventId(), eventUpdateDto.getSchedules());
+    }
+
+    return mapToEventResponseDto(existingEvent);
+  }
+
+  private Event findEventById(Long eventId) {
+    return eventRepository.findById(eventId);
+  }
+
+  private void updateEventInfo(Event event, EventUpdateDto updateDto) {
+    event.setTitle(updateDto.getTitle());
+    event.setAgeLimit(updateDto.getAgeLimit());
+    event.setDescription(updateDto.getDescription());
+    event.setGenre(updateDto.getGenre());
+    event.setThumbnailUrl(updateDto.getThumbnailUrl());
+    if (updateDto.getStatus() != null) {
+      event.setStatus(updateDto.getStatus());
+    }
+    event.setUpdatedAt(LocalDateTime.now());
+    
+    // 이벤트 정보 저장
+    eventRepository.updateEvent(event);
+  }
+
+  private void updateEventSchedules(Long eventId, List<EventScheduleUpdateDto> scheduleDtos) {
+    for (EventScheduleUpdateDto scheduleDto : scheduleDtos) {
+      if (scheduleDto.getEventScheduleId() != null) {
+        // 기존 스케줄 업데이트
+        updateExistingSchedule(scheduleDto);
+      } else {
+        // 새 스케줄 추가
+        addNewSchedule(eventId, scheduleDto);
+      }
+    }
+  }
+
+  private void updateExistingSchedule(EventScheduleUpdateDto scheduleDto) {
+    EventSchedule schedule = mapToEventScheduleForUpdate(scheduleDto);
+    eventScheduleRepository.updateEventSchedule(schedule);
+    
+    // 가격 정보 업데이트
+    if (scheduleDto.getPrices() != null) {
+      updateSchedulePrices(scheduleDto.getEventScheduleId(), scheduleDto.getPrices());
+    }
+  }
+
+  private void addNewSchedule(Long eventId, EventScheduleUpdateDto scheduleDto) {
+    scheduleDto.setEventScheduleId(null); // 새 스케줄임을 명시
+    EventSchedule newSchedule = mapToEventScheduleForUpdate(scheduleDto);
+    newSchedule.setEventId(eventId);
+    
+    eventScheduleRepository.save(newSchedule);
+    Long newScheduleId = newSchedule.getEventScheduleId();
+    
+    // 새 가격 정보 추가
+    if (scheduleDto.getPrices() != null) {
+      for (PriceUpdateDto priceDto : scheduleDto.getPrices()) {
+        Price price = mapToPriceForUpdate(priceDto);
+        price.setEventScheduleId(newScheduleId);
+        priceRepository.save(price);
+      }
+    }
+  }
+
+  private void updateSchedulePrices(Long scheduleId, List<PriceUpdateDto> priceDtos) {
+    for (PriceUpdateDto priceDto : priceDtos) {
+      if (priceDto.getPriceId() != null) {
+        // 기존 가격 업데이트
+        Price price = mapToPriceForUpdate(priceDto);
+        price.setEventScheduleId(scheduleId);
+        priceRepository.updatePrice(price);
+      } else {
+        // 새 가격 추가
+        Price newPrice = mapToPriceForUpdate(priceDto);
+        newPrice.setEventScheduleId(scheduleId);
+        priceRepository.save(newPrice);
+      }
+    }
+  }
+
+  private EventSchedule mapToEventScheduleForUpdate(EventScheduleUpdateDto dto) {
+    return EventSchedule.builder()
+        .eventScheduleId(dto.getEventScheduleId())
+        .venueId(dto.getVenueId())
+        .ticketOpenAt(dto.getTicketOpenAt())
+        .eventDate(dto.getEventDate())
+        .updatedAt(LocalDateTime.now())
+        .build();
+  }
+
+  private Price mapToPriceForUpdate(PriceUpdateDto dto) {
+    return Price.builder()
+        .priceId(dto.getPriceId())
+        .seatClassId(dto.getSeatClassId())
+        .price(dto.getPrice())
+        .updatedAt(LocalDateTime.now())
+        .build();
+  }
+
   @Transactional
   public EventResponseDto registerEvent(EventRegisterDto eventRegisterDto) {
 
@@ -52,6 +191,9 @@ public class EventService {
     // 새로 추가된 공연 status PENDING으로 설정
     eventRegisterDto.setStatus(Event.EventStatus.PENDING);
 
+    // 임시로 account_id를 1로 설정 (account 서비스 완료 전까지)
+    eventRegisterDto.setAccountId(1L);
+
     // Create and save event
     Event event = mapToEvent(eventRegisterDto);
     Long eventId = saveEvent(event);
@@ -60,8 +202,19 @@ public class EventService {
     // Create and save schedules and prices if present
     if (eventRegisterDto.getSchedules() != null) {
       for (EventScheduleDto scheduleDto : eventRegisterDto.getSchedules()) {
+        // 새로운 eventId를 설정
         scheduleDto.setEventId(eventId);
-        EventSchedule eventSchedule = mapToEventSchedule(scheduleDto);
+        
+        // EventSchedule 생성 시 eventId를 직접 전달
+        EventSchedule eventSchedule = EventSchedule.builder()
+            .eventId(eventId)  // 직접 eventId 설정
+            .venueId(scheduleDto.getVenueId())
+            .ticketOpenAt(scheduleDto.getTicketOpenAt())
+            .eventDate(scheduleDto.getEventDate())
+            .createdAt(LocalDateTime.now())
+            .updatedAt(LocalDateTime.now())
+            .build();
+            
         Long eventScheduleId = saveEventSchedule(eventSchedule);
 
         // Save prices if present
@@ -83,16 +236,19 @@ public class EventService {
   }
 
   private Event mapToEvent(EventRegisterDto dto) {
-    return Event.builder().tenantId(dto.getTenantId()).title(dto.getTitle())
+    return Event.builder().accountId(dto.getAccountId()).title(dto.getTitle())
         .ageLimit(dto.getAgeLimit()).description(dto.getDescription()).genre(dto.getGenre())
         .thumbnailUrl(dto.getThumbnailUrl()).status(dto.getStatus()).createdAt(LocalDateTime.now())
         .updatedAt(LocalDateTime.now()).build();
   }
 
-  private EventSchedule mapToEventSchedule(EventScheduleDto dto) {
-    return EventSchedule.builder().eventId(dto.getEventId()).venueId(dto.getVenueId())
+  private EventSchedule mapToEventSchedule(EventScheduleDto dto, Long eventId) {
+    System.out.println("mapToEventSchedule - dto.getEventId(): " + dto.getEventId() + ", passed eventId: " + eventId);
+    EventSchedule eventSchedule = EventSchedule.builder().eventId(eventId).venueId(dto.getVenueId())
         .ticketOpenAt(dto.getTicketOpenAt()).eventDate(dto.getEventDate())
         .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).build();
+    System.out.println("mapToEventSchedule - built eventSchedule.eventId: " + eventSchedule.getEventId());
+    return eventSchedule;
   }
 
   private Price mapToPrice(PriceDto dto) {
@@ -102,18 +258,32 @@ public class EventService {
   }
 
   private EventResponseDto mapToEventResponseDto(Event event) {
-    return EventResponseDto.builder().eventId(event.getEventId()).tenantId(event.getTenantId())
-        .title(event.getTitle()).ageLimit(event.getAgeLimit()).description(event.getDescription())
-        .genre(event.getGenre()).thumbnailUrl(event.getThumbnailUrl()).status(event.getStatus())
-        .createdAt(event.getCreatedAt()).updatedAt(event.getUpdatedAt()).build();
+    EventResponseDto responseDto = new EventResponseDto();
+    responseDto.setEventId(event.getEventId());
+    responseDto.setAccountId(event.getAccountId());
+    responseDto.setTitle(event.getTitle());
+    responseDto.setAgeLimit(event.getAgeLimit());
+    responseDto.setDescription(event.getDescription());
+    responseDto.setGenre(event.getGenre());
+    responseDto.setThumbnailUrl(event.getThumbnailUrl());
+    responseDto.setStatus(event.getStatus());
+    responseDto.setCreatedAt(event.getCreatedAt());
+    responseDto.setUpdatedAt(event.getUpdatedAt());
+    return responseDto;
   }
 
   private Long saveEvent(Event event) {
-    return eventRepository.save(event);
+    // save() 메서드는 영향받은 행의 수(1)를 반환
+    eventRepository.save(event);
+    // event 객체에는 생성된 ID가 설정되어 있음
+    return event.getEventId();
   }
 
   private Long saveEventSchedule(EventSchedule eventSchedule) {
-    return eventScheduleRepository.save(eventSchedule);
+    // save() 메서드는 영향받은 행의 수(1)를 반환
+    eventScheduleRepository.save(eventSchedule);
+    // eventSchedule 객체에는 생성된 ID가 설정되어 있음
+    return eventSchedule.getEventScheduleId();
   }
 
   private Long savePrice(Price price) {

--- a/event/src/main/resources/mapper/EventMapper.xml
+++ b/event/src/main/resources/mapper/EventMapper.xml
@@ -1,53 +1,102 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE mapper
-        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.pyokemon.event.repository.EventRepository">
-    <insert id="save" parameterType="Event" useGeneratedKeys="true" keyProperty="eventId" keyColumn="event_id">
+
+    <resultMap id="EventResultMap" type="com.pyokemon.event.entity.Event">
+        <id column="event_id" property="eventId"/>
+        <result column="account_id" property="accountId"/>
+        <result column="title" property="title"/>
+        <result column="age_limit" property="ageLimit"/>
+        <result column="description" property="description"/>
+        <result column="genre" property="genre"/>
+        <result column="thumbnail_url" property="thumbnailUrl"/>
+        <result column="status" property="status"/>
+        <result column="created_at" property="createdAt"/>
+        <result column="updated_at" property="updatedAt"/>
+    </resultMap>
+
+    <select id="findById" resultMap="EventResultMap">
+        SELECT * FROM tb_event WHERE event_id = #{eventId}
+    </select>
+
+    <select id="findByTenantId" resultMap="EventResultMap">
+        SELECT * FROM tb_event WHERE account_id = #{tenantId}
+    </select>
+
+    <select id="findByAccountId" resultMap="EventResultMap">
+        SELECT * FROM tb_event WHERE account_id = #{accountId}
+    </select>
+
+    <select id="findTenantEventListByAccountId" resultType="com.pyokemon.event.dto.TenantEventListDto">
+        SELECT 
+            e.event_id as eventId,
+            e.thumbnail_url as thumbnailUrl,
+            e.title,
+            es.event_date as eventDate,
+            v.venue_name as venueName,
+            e.status
+        FROM tb_event e
+        LEFT JOIN tb_event_schedule es ON e.event_id = es.event_id
+        LEFT JOIN tb_venue v ON es.venue_id = v.venue_id
+        WHERE e.account_id = #{accountId}
+        ORDER BY es.event_date ASC
+    </select>
+
+    <select id="findByStatus" resultMap="EventResultMap">
+        SELECT * FROM tb_event WHERE status = #{status}
+    </select>
+
+    <select id="findByGenre" resultMap="EventResultMap">
+        SELECT * FROM tb_event WHERE genre = #{genre}
+    </select>
+
+    <select id="findByTitleContainingIgnoreCase" resultMap="EventResultMap">
+        SELECT * FROM tb_event WHERE LOWER(title) LIKE LOWER(CONCAT('%', #{title}, '%'))
+    </select>
+
+    <select id="findByAgeLimit" resultMap="EventResultMap">
+        SELECT * FROM tb_event WHERE age_limit = #{ageLimit}
+    </select>
+
+    <insert id="save" parameterType="com.pyokemon.event.entity.Event" useGeneratedKeys="true" keyProperty="eventId">
         INSERT INTO tb_event (
-            tenant_id,
-            title,
-            age_limit,
-            description,
-            genre,
-            thumbnail_url,
-            status,
-            created_at,
-            updated_at
+            account_id, title, age_limit, description, genre, 
+            thumbnail_url, status, created_at, updated_at
         ) VALUES (
-            #{tenantId},
-            #{title},
-            #{ageLimit},
-            #{description},
-            #{genre},
-            #{thumbnailUrl},
-            #{status},
-            #{createdAt},
-            #{updatedAt}
+            #{accountId}, #{title}, #{ageLimit}, #{description}, #{genre}, 
+            #{thumbnailUrl}, #{status}, #{createdAt}, #{updatedAt}
         )
         <selectKey resultType="long" keyProperty="eventId" order="AFTER">
             SELECT LAST_INSERT_ID()
         </selectKey>
     </insert>
 
-    <select id="findEventDetailByEventId" resultType="EventDetailResponseDTO">
-        SELECT
-        e.event_id,
-        e.title,
-        e.age_limit,
-        e.description,
-        e.genre,
-        e.thumbnail_url,
-        es.event_schedule_id,
-        es.ticket_open_at,
-        es.event_date,
-        v.venue_name
-        FROM tb_event e
-        JOIN tb_event_schedule es ON es.event_id = e.event_id
-        JOIN tb_venue v ON es.venue_id = v.venue_id
+    <update id="updateEvent" parameterType="com.pyokemon.event.entity.Event">
+        UPDATE tb_event SET
+            title = #{title},
+            age_limit = #{ageLimit},
+            description = #{description},
+            genre = #{genre},
+            thumbnail_url = #{thumbnailUrl},
+            status = #{status},
+            updated_at = #{updatedAt}
+        WHERE event_id = #{eventId}
+    </update>
 
-        WHERE e.event_id = #{event_id}
+    <select id="findEventDetailByEventId" resultType="com.pyokemon.event.dto.EventDetailResponseDTO">
+        SELECT 
+            e.event_id as eventId,
+            e.account_id as accountId,
+            e.title,
+            e.age_limit as ageLimit,
+            e.description,
+            e.genre,
+            e.thumbnail_url as thumbnailUrl,
+            e.status,
+            e.created_at as createdAt,
+            e.updated_at as updatedAt
+        FROM tb_event e
+        WHERE e.event_id = #{eventId}
     </select>
 
 </mapper>

--- a/event/src/main/resources/mapper/EventMapper.xml
+++ b/event/src/main/resources/mapper/EventMapper.xml
@@ -99,4 +99,50 @@
         WHERE e.event_id = #{eventId}
     </select>
 
+    <resultMap id="TenantEventDetailResultMap" type="com.pyokemon.event.dto.TenantEventDetailResponseDTO">
+        <id column="event_id" property="eventId"/>
+        <result column="title" property="title"/>
+        <result column="age_limit" property="ageLimit"/>
+        <result column="description" property="description"/>
+        <result column="genre" property="genre"/>
+        <result column="thumbnail_url" property="thumbnailUrl"/>
+        <result column="status" property="status"/>
+        <result column="event_schedule_id" property="eventScheduleId"/>
+        <result column="ticket_open_at" property="ticketOpenAt"/>
+        <result column="event_date" property="eventDate"/>
+        <result column="venue_name" property="venueName"/>
+        <collection property="prices" ofType="com.pyokemon.event.dto.TenantEventDetailResponseDTO$PriceInfo">
+            <id column="price_id" property="priceId"/>
+            <result column="seat_class_id" property="seatClassId"/>
+            <result column="class_name" property="className"/>
+            <result column="price" property="price"/>
+        </collection>
+    </resultMap>
+
+    <select id="findTenantEventDetailByEventId" resultMap="TenantEventDetailResultMap">
+        SELECT 
+            e.event_id,
+            e.title,
+            e.age_limit,
+            e.description,
+            e.genre,
+            e.thumbnail_url,
+            e.status,
+            es.event_schedule_id,
+            es.ticket_open_at,
+            es.event_date,
+            v.venue_name,
+            p.price_id,
+            p.seat_class_id,
+            sc.class_name,
+            p.price
+        FROM tb_event e
+        LEFT JOIN tb_event_schedule es ON e.event_id = es.event_id
+        LEFT JOIN tb_venue v ON es.venue_id = v.venue_id
+        LEFT JOIN tb_price p ON es.event_schedule_id = p.event_schedule_id
+        LEFT JOIN tb_seat_class sc ON p.seat_class_id = sc.seat_class_id
+        WHERE e.event_id = #{eventId}
+        ORDER BY sc.priority ASC
+    </select>
+
 </mapper>

--- a/event/src/main/resources/mapper/EventMapper.xml
+++ b/event/src/main/resources/mapper/EventMapper.xml
@@ -30,6 +30,7 @@
     <select id="findTenantEventListByAccountId" resultType="com.pyokemon.event.dto.TenantEventListDto">
         SELECT 
             e.event_id as eventId,
+            es.event_schedule_id as eventScheduleId,
             e.thumbnail_url as thumbnailUrl,
             e.title,
             es.event_date as eventDate,
@@ -142,6 +143,55 @@
         LEFT JOIN tb_price p ON es.event_schedule_id = p.event_schedule_id
         LEFT JOIN tb_seat_class sc ON p.seat_class_id = sc.seat_class_id
         WHERE e.event_id = #{eventId}
+        ORDER BY sc.priority ASC
+    </select>
+
+    <resultMap id="TenantBookingDetailResultMap" type="com.pyokemon.event.dto.TenantBookingDetailResponseDTO">
+        <id column="event_id" property="eventId"/>
+        <result column="title" property="title"/>
+        <result column="genre" property="genre"/>
+        <result column="status" property="status"/>
+        <result column="event_schedule_id" property="eventScheduleId"/>
+        <result column="ticket_open_at" property="ticketOpenAt"/>
+        <result column="event_date" property="eventDate"/>
+        <result column="venue_name" property="venueName"/>
+        <collection property="bookingStatus" ofType="com.pyokemon.event.dto.TenantBookingDetailResponseDTO$BookingStatusInfo">
+            <result column="seat_class_id" property="seatClassId"/>
+            <result column="class_name" property="className"/>
+            <result column="total_seats" property="totalSeats"/>
+            <result column="booked_seats" property="bookedSeats"/>
+            <result column="available_seats" property="availableSeats"/>
+            <result column="price" property="price"/>
+            <result column="booking_rate" property="bookingRate"/>
+        </collection>
+    </resultMap>
+
+    <select id="findTenantBookingDetailByEventScheduleId" resultMap="TenantBookingDetailResultMap">
+        SELECT 
+            e.event_id,
+            e.title,
+            e.genre,
+            e.status,
+            es.event_schedule_id,
+            es.ticket_open_at,
+            es.event_date,
+            v.venue_name,
+            sc.seat_class_id,
+            sc.class_name,
+            COUNT(s.seat_id) as total_seats,
+            COUNT(CASE WHEN b.booking_id IS NOT NULL THEN 1 END) as booked_seats,
+            COUNT(CASE WHEN b.booking_id IS NULL THEN 1 END) as available_seats,
+            p.price,
+            ROUND(COUNT(CASE WHEN b.booking_id IS NOT NULL THEN 1 END) * 100.0 / COUNT(s.seat_id), 2) as booking_rate
+        FROM tb_event e
+        JOIN tb_event_schedule es ON e.event_id = es.event_id
+        JOIN tb_venue v ON es.venue_id = v.venue_id
+        JOIN tb_seat s ON v.venue_id = s.venue_id
+        JOIN tb_seat_class sc ON s.seat_class_id = sc.seat_class_id
+        LEFT JOIN tb_price p ON es.event_schedule_id = p.event_schedule_id AND sc.seat_class_id = p.seat_class_id
+        LEFT JOIN tb_booking b ON es.event_schedule_id = b.event_schedule_id AND s.seat_id = b.seat_id AND b.status = 'BOOKED'
+        WHERE es.event_schedule_id = #{eventScheduleId}
+        GROUP BY sc.seat_class_id, sc.class_name, p.price
         ORDER BY sc.priority ASC
     </select>
 

--- a/event/src/main/resources/mapper/EventScheduleMapper.xml
+++ b/event/src/main/resources/mapper/EventScheduleMapper.xml
@@ -150,7 +150,6 @@
              e.genre = #{genre} AND
         </if>
             e.status = 'APPROVED'
-            e.genre = #{genre}
     </select>
 
 

--- a/event/src/main/resources/mapper/EventScheduleMapper.xml
+++ b/event/src/main/resources/mapper/EventScheduleMapper.xml
@@ -25,30 +25,42 @@
         </selectKey>
     </insert>
 
-
-    <select id="findById" resultType="EventSchedule" parameterType="long">
-        SELECT event_schedule_id, event_id, venue_id, event_date, ticket_open_at, created_at, updated_at
-        FROM tb_event_schedule
-        WHERE event_schedule_id = #{param1}
-    </select>
+    
 
 
-    <select id="selectTodayOpenedTickets" resultType="EventItemResponseDTO">
-        SELECT
-            es.event_schedule_id,
-            es.event_id,
-            es.venue_id,
-            es.ticket_open_at,
-            es.event_date,
-            e.title AS title,
-            v.venue_name AS venue_name,
-            e.thumbnail_url
-        FROM tb_event_schedule es
-                 JOIN tb_event e ON es.event_id = e.event_id
-                 JOIN tb_venue v ON es.venue_id = v.venue_id
-        WHERE DATE(es.ticket_open_at) = CURDATE()
-        LIMIT 9
-    </select>
+         <select id="findById" resultType="EventSchedule" parameterType="long">
+         SELECT event_schedule_id, event_id, venue_id, event_date, ticket_open_at, created_at, updated_at
+         FROM tb_event_schedule
+         WHERE event_schedule_id = #{param1}
+     </select>
+
+     <update id="updateEventSchedule" parameterType="EventSchedule">
+         UPDATE tb_event_schedule SET
+             venue_id = #{venueId},
+             ticket_open_at = #{ticketOpenAt},
+             event_date = #{eventDate},
+             updated_at = #{updatedAt}
+         WHERE event_schedule_id = #{eventScheduleId}
+     </update>
+
+
+         <select id="selectTodayOpenedTickets" resultType="EventItemResponseDTO">
+         SELECT
+             es.event_schedule_id,
+             es.event_id,
+             es.venue_id,
+             es.ticket_open_at,
+             es.event_date,
+             e.title AS title,
+             v.venue_name AS venue_name,
+             e.genre,
+             e.thumbnail_url
+         FROM tb_event_schedule es
+                  JOIN tb_event e ON es.event_id = e.event_id
+                  JOIN tb_venue v ON es.venue_id = v.venue_id
+         WHERE DATE(es.ticket_open_at) = CURDATE()
+         LIMIT 9
+     </select>
 
     <select id="selectTicketsToBeOpened" resultType="EventItemResponseDTO">
         SELECT
@@ -78,7 +90,8 @@
             e.title AS title,
             v.venue_name AS venue_name,
             e.genre,
-            e.thumbnail_url
+            e.thumbnail_url,
+            e.status
         FROM tb_event_schedule es
                  JOIN tb_event e ON es.event_id = e.event_id
                  JOIN tb_venue v ON es.venue_id = v.venue_id
@@ -87,6 +100,7 @@
         <if test="genre != null and genre != '전체'">
             AND e.genre = #{genre}
         </if>
+            e.genre = #{genre}
             LIMIT #{limit} OFFSET #{offset}
     </select>
 
@@ -136,6 +150,7 @@
              e.genre = #{genre} AND
         </if>
             e.status = 'APPROVED'
+            e.genre = #{genre}
     </select>
 
 

--- a/event/src/main/resources/mapper/EventScheduleMapper.xml
+++ b/event/src/main/resources/mapper/EventScheduleMapper.xml
@@ -25,42 +25,30 @@
         </selectKey>
     </insert>
 
-    
+
+    <select id="findById" resultType="EventSchedule" parameterType="long">
+        SELECT event_schedule_id, event_id, venue_id, event_date, ticket_open_at, created_at, updated_at
+        FROM tb_event_schedule
+        WHERE event_schedule_id = #{param1}
+    </select>
 
 
-         <select id="findById" resultType="EventSchedule" parameterType="long">
-         SELECT event_schedule_id, event_id, venue_id, event_date, ticket_open_at, created_at, updated_at
-         FROM tb_event_schedule
-         WHERE event_schedule_id = #{param1}
-     </select>
-
-     <update id="updateEventSchedule" parameterType="EventSchedule">
-         UPDATE tb_event_schedule SET
-             venue_id = #{venueId},
-             ticket_open_at = #{ticketOpenAt},
-             event_date = #{eventDate},
-             updated_at = #{updatedAt}
-         WHERE event_schedule_id = #{eventScheduleId}
-     </update>
-
-
-         <select id="selectTodayOpenedTickets" resultType="EventItemResponseDTO">
-         SELECT
-             es.event_schedule_id,
-             es.event_id,
-             es.venue_id,
-             es.ticket_open_at,
-             es.event_date,
-             e.title AS title,
-             v.venue_name AS venue_name,
-             e.genre,
-             e.thumbnail_url
-         FROM tb_event_schedule es
-                  JOIN tb_event e ON es.event_id = e.event_id
-                  JOIN tb_venue v ON es.venue_id = v.venue_id
-         WHERE DATE(es.ticket_open_at) = CURDATE()
-         LIMIT 9
-     </select>
+    <select id="selectTodayOpenedTickets" resultType="EventItemResponseDTO">
+        SELECT
+            es.event_schedule_id,
+            es.event_id,
+            es.venue_id,
+            es.ticket_open_at,
+            es.event_date,
+            e.title AS title,
+            v.venue_name AS venue_name,
+            e.thumbnail_url
+        FROM tb_event_schedule es
+                 JOIN tb_event e ON es.event_id = e.event_id
+                 JOIN tb_venue v ON es.venue_id = v.venue_id
+        WHERE DATE(es.ticket_open_at) = CURDATE()
+        LIMIT 9
+    </select>
 
     <select id="selectTicketsToBeOpened" resultType="EventItemResponseDTO">
         SELECT
@@ -90,8 +78,7 @@
             e.title AS title,
             v.venue_name AS venue_name,
             e.genre,
-            e.thumbnail_url,
-            e.status
+            e.thumbnail_url
         FROM tb_event_schedule es
                  JOIN tb_event e ON es.event_id = e.event_id
                  JOIN tb_venue v ON es.venue_id = v.venue_id
@@ -100,7 +87,6 @@
         <if test="genre != null and genre != '전체'">
             AND e.genre = #{genre}
         </if>
-            e.genre = #{genre}
             LIMIT #{limit} OFFSET #{offset}
     </select>
 

--- a/event/src/main/resources/mapper/PriceMapper.xml
+++ b/event/src/main/resources/mapper/PriceMapper.xml
@@ -26,10 +26,18 @@
             #{createdAt},
             #{updatedAt}
         )
-        <selectKey resultType="long" keyProperty="priceId" order="AFTER">
-            SELECT LAST_INSERT_ID()
-        </selectKey>
-    </insert>
-  
+                 <selectKey resultType="long" keyProperty="priceId" order="AFTER">
+             SELECT LAST_INSERT_ID()
+         </selectKey>
+     </insert>
+
+     <update id="updatePrice" parameterType="Price">
+         UPDATE tb_price SET
+             seat_class_id = #{seatClassId},
+             price = #{price},
+             updated_at = #{updatedAt}
+         WHERE price_id = #{priceId}
+     </update>
+     
 </mapper> 
 

--- a/event/src/main/resources/mapper/VenueMapper.xml
+++ b/event/src/main/resources/mapper/VenueMapper.xml
@@ -13,7 +13,7 @@
             created_at,
             updated_at
         FROM tb_venue 
-        WHERE venue_id = #{venueId}
+        WHERE venue_id = #{id}
     </select>
     
 </mapper> 

--- a/event/src/test/java/com/pyokemon/event/controller/EventManageControllerTest.java
+++ b/event/src/test/java/com/pyokemon/event/controller/EventManageControllerTest.java
@@ -1,0 +1,163 @@
+package com.pyokemon.event.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pyokemon.event.dto.EventRegisterDto;
+import com.pyokemon.event.dto.EventResponseDto;
+import com.pyokemon.event.dto.EventScheduleDto;
+import com.pyokemon.event.dto.EventUpdateDto;
+import com.pyokemon.event.dto.PriceDto;
+import com.pyokemon.event.dto.TenantEventDetailResponseDTO;
+import com.pyokemon.event.dto.TenantEventListDto;
+import com.pyokemon.event.entity.Event.EventStatus;
+import com.pyokemon.event.service.EventScheduleService;
+import com.pyokemon.event.service.EventService;
+
+@WebMvcTest(EventController.class)
+class TenantEventManagementControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private EventService eventService;
+
+  @MockBean
+  private EventScheduleService eventScheduleService;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  private Long validAccountId = 1L;
+  private Long validEventId = 1L;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트 설정
+  }
+
+  @Test
+  @DisplayName("TenantEventListTest - 테넌트별 공연 목록 조회 API 테스트")
+  void getTenantEventList_Success() throws Exception {
+    // given
+    TenantEventListDto mockEvent = TenantEventListDto.builder().eventId(validEventId)
+        .title("테스트 공연").eventDate(LocalDateTime.now().plusDays(30)).venueName("테스트 공연장")
+        .status("APPROVED").build();
+
+    when(eventService.getTenantEventListByAccountId(validAccountId)).thenReturn(List.of(mockEvent));
+
+    // when & then
+    mockMvc.perform(get("/api/events/tenant").param("account_id", validAccountId.toString()))
+        .andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data[0].eventId").value(1))
+        .andExpect(jsonPath("$.data[0].title").value("테스트 공연"))
+        .andExpect(jsonPath("$.data[0].venueName").value("테스트 공연장"))
+        .andExpect(jsonPath("$.data[0].status").value("APPROVED"));
+
+    verify(eventService).getTenantEventListByAccountId(validAccountId);
+  }
+
+  @Test
+  @DisplayName("TenantEventDetailTest - 테넌트별 공연 상세 조회 API 테스트")
+  void getTenantEventDetail_Success() throws Exception {
+    // given
+    TenantEventDetailResponseDTO mockDetail =
+        TenantEventDetailResponseDTO.builder().eventId(validEventId).title("테스트 공연").ageLimit(12L)
+            .description("테스트 공연 설명").genre("콘서트").thumbnailUrl("https://example.com/image.jpg")
+            .status("APPROVED").eventScheduleId(1L).ticketOpenAt(LocalDateTime.now().plusDays(7))
+            .eventDate(LocalDateTime.now().plusDays(30)).venueName("테스트 공연장")
+            .prices(List.of(
+                TenantEventDetailResponseDTO.PriceInfo.builder().priceId(1L).seatClassId(1L)
+                    .className("VIP").price(150000).build(),
+                TenantEventDetailResponseDTO.PriceInfo.builder().priceId(2L).seatClassId(2L)
+                    .className("R석").price(100000).build()))
+            .build();
+
+    when(eventService.getTenantEventDetailByEventId(validEventId)).thenReturn(mockDetail);
+
+    // when & then
+    mockMvc.perform(get("/api/events/tenant/{eventId}/detail", validEventId))
+        .andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.eventId").value(1))
+        .andExpect(jsonPath("$.data.title").value("테스트 공연"))
+        .andExpect(jsonPath("$.data.venueName").value("테스트 공연장"))
+        .andExpect(jsonPath("$.data.prices[0].className").value("VIP"))
+        .andExpect(jsonPath("$.data.prices[0].price").value(150000))
+        .andExpect(jsonPath("$.data.prices[1].className").value("R석"))
+        .andExpect(jsonPath("$.data.prices[1].price").value(100000));
+
+    verify(eventService).getTenantEventDetailByEventId(validEventId);
+  }
+
+  @Test
+  @DisplayName("EventRegistTest - 공연 등록 API 테스트")
+  void registerEvent_Success() throws Exception {
+    // given
+    EventRegisterDto registerDto =
+        EventRegisterDto.builder().accountId(validAccountId).title("새로운 공연").ageLimit(12L)
+            .description("새로운 공연 설명").genre("뮤지컬").thumbnailUrl("https://example.com/new-image.jpg")
+            .schedules(List.of(
+                EventScheduleDto.builder().venueId(1L).ticketOpenAt(LocalDateTime.now().plusDays(7))
+                    .eventDate(LocalDateTime.now().plusDays(30))
+                    .prices(List.of(PriceDto.builder().seatClassId(1L).price(150000).build(),
+                        PriceDto.builder().seatClassId(2L).price(100000).build()))
+                    .build()))
+            .build();
+
+    EventResponseDto mockResponse = EventResponseDto.builder().eventId(validEventId)
+        .accountId(validAccountId).title("새로운 공연").status(EventStatus.PENDING).build();
+
+    when(eventService.registerEvent(any(EventRegisterDto.class))).thenReturn(mockResponse);
+
+    // when & then
+    mockMvc
+        .perform(post("/api/events").contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(registerDto)))
+        .andExpect(status().isCreated()).andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.title").value("새로운 공연"))
+        .andExpect(jsonPath("$.data.status").value("PENDING"))
+        .andExpect(jsonPath("$.message").value("Event registered successfully"));
+
+    verify(eventService).registerEvent(any(EventRegisterDto.class));
+  }
+
+  @Test
+  @DisplayName("EventEditTest - 공연 수정 API 테스트")
+  void updateEvent_Success() throws Exception {
+    // given
+    EventUpdateDto updateDto = EventUpdateDto.builder().eventId(validEventId).title("수정된 공연")
+        .ageLimit(15L).description("수정된 공연 설명").genre("연극")
+        .thumbnailUrl("https://example.com/updated-image.jpg").status(EventStatus.APPROVED).build();
+
+    EventResponseDto mockResponse = EventResponseDto.builder().eventId(validEventId)
+        .accountId(validAccountId).title("수정된 공연").status(EventStatus.APPROVED).build();
+
+    when(eventService.updateEvent(any(EventUpdateDto.class))).thenReturn(mockResponse);
+
+    // when & then
+    mockMvc
+        .perform(put("/api/events/{eventId}", validEventId).contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(updateDto)))
+        .andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.title").value("수정된 공연"))
+        .andExpect(jsonPath("$.data.status").value("APPROVED"))
+        .andExpect(jsonPath("$.message").value("Event updated successfully"));
+
+    verify(eventService).updateEvent(any(EventUpdateDto.class));
+  }
+}

--- a/event/src/test/java/com/pyokemon/event/service/EventManagementServiceTest.java
+++ b/event/src/test/java/com/pyokemon/event/service/EventManagementServiceTest.java
@@ -1,0 +1,174 @@
+package com.pyokemon.event.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.pyokemon.event.dto.EventDetailResponseDTO;
+import com.pyokemon.event.dto.EventRegisterDto;
+import com.pyokemon.event.dto.EventResponseDto;
+import com.pyokemon.event.dto.EventScheduleDto;
+import com.pyokemon.event.dto.EventUpdateDto;
+import com.pyokemon.event.dto.PriceDto;
+import com.pyokemon.event.dto.TenantEventDetailResponseDTO;
+import com.pyokemon.event.dto.TenantEventListDto;
+import com.pyokemon.event.entity.Event;
+import com.pyokemon.event.entity.Event.EventStatus;
+import com.pyokemon.event.entity.Venue;
+import com.pyokemon.event.repository.EventRepository;
+import com.pyokemon.event.repository.EventScheduleRepository;
+import com.pyokemon.event.repository.PriceRepository;
+import com.pyokemon.event.repository.VenueRepository;
+
+@ExtendWith(MockitoExtension.class)
+class TenantEventManagementServiceTest {
+
+  @Mock
+  private EventRepository eventRepository;
+
+  @Mock
+  private EventScheduleRepository eventScheduleRepository;
+
+  @Mock
+  private VenueRepository venueRepository;
+
+  @Mock
+  private PriceRepository priceRepository;
+
+  @InjectMocks
+  private EventService eventService;
+
+  private Long validAccountId = 1L;
+  private Long validEventId = 1L;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트 설정
+  }
+
+  @Test
+  @DisplayName("TenantEventListTest - 테넌트별 공연 목록 조회 성공")
+  void getTenantEventListByAccountId_Success() {
+    // given
+    TenantEventListDto mockEvent = TenantEventListDto.builder().eventId(validEventId)
+        .title("테스트 공연").eventDate(LocalDateTime.now().plusDays(30)).venueName("테스트 공연장")
+        .status("APPROVED").build();
+
+    when(eventRepository.findTenantEventListByAccountId(validAccountId))
+        .thenReturn(List.of(mockEvent));
+
+    // when
+    List<TenantEventListDto> result = eventService.getTenantEventListByAccountId(validAccountId);
+
+    // then
+    assertNotNull(result);
+    assertEquals(1, result.size());
+    assertEquals("테스트 공연", result.get(0).getTitle());
+    assertEquals("테스트 공연장", result.get(0).getVenueName());
+    assertEquals("APPROVED", result.get(0).getStatus());
+    verify(eventRepository).findTenantEventListByAccountId(validAccountId);
+  }
+
+  @Test
+  @DisplayName("TenantEventDetailTest - 테넌트별 공연 상세 조회 성공")
+  void getTenantEventDetailByEventId_Success() {
+    // given
+    TenantEventDetailResponseDTO mockDetail =
+        TenantEventDetailResponseDTO.builder().eventId(validEventId).title("테스트 공연").ageLimit(12L)
+            .description("테스트 공연 설명").genre("콘서트").thumbnailUrl("https://example.com/image.jpg")
+            .status("APPROVED").eventScheduleId(1L).ticketOpenAt(LocalDateTime.now().plusDays(7))
+            .eventDate(LocalDateTime.now().plusDays(30)).venueName("테스트 공연장")
+            .prices(List.of(
+                TenantEventDetailResponseDTO.PriceInfo.builder().priceId(1L).seatClassId(1L)
+                    .className("VIP").price(150000).build(),
+                TenantEventDetailResponseDTO.PriceInfo.builder().priceId(2L).seatClassId(2L)
+                    .className("R석").price(100000).build()))
+            .build();
+
+    when(eventRepository.findTenantEventDetailByEventId(validEventId)).thenReturn(mockDetail);
+
+    // when
+    TenantEventDetailResponseDTO result = eventService.getTenantEventDetailByEventId(validEventId);
+
+    // then
+    assertNotNull(result);
+    assertEquals("테스트 공연", result.getTitle());
+    assertEquals("테스트 공연장", result.getVenueName());
+    assertEquals(2, result.getPrices().size());
+    assertEquals("VIP", result.getPrices().get(0).getClassName());
+    assertEquals(150000, result.getPrices().get(0).getPrice());
+    assertEquals("R석", result.getPrices().get(1).getClassName());
+    assertEquals(100000, result.getPrices().get(1).getPrice());
+    verify(eventRepository).findTenantEventDetailByEventId(validEventId);
+  }
+
+  @Test
+  @DisplayName("EventRegistTest - 공연 등록 성공")
+  void registerEvent_Success() {
+    // given
+    EventRegisterDto registerDto =
+        EventRegisterDto.builder().accountId(validAccountId).title("새로운 공연").ageLimit(12L)
+            .description("새로운 공연 설명").genre("뮤지컬").thumbnailUrl("https://example.com/new-image.jpg")
+            .schedules(List.of(
+                EventScheduleDto.builder().venueId(1L).ticketOpenAt(LocalDateTime.now().plusDays(7))
+                    .eventDate(LocalDateTime.now().plusDays(30))
+                    .prices(List.of(PriceDto.builder().seatClassId(1L).price(150000).build(),
+                        PriceDto.builder().seatClassId(2L).price(100000).build()))
+                    .build()))
+            .build();
+
+    Event mockEvent = Event.builder().eventId(validEventId).accountId(validAccountId)
+        .title("새로운 공연").status(EventStatus.PENDING).build();
+
+    when(venueRepository.findById(1L)).thenReturn(java.util.Optional.of(new Venue()));
+    when(eventRepository.save(any(Event.class))).thenReturn(1);
+    when(eventScheduleRepository.save(any())).thenReturn(1);
+    when(priceRepository.save(any())).thenReturn(1L);
+
+    // when
+    EventResponseDto result = eventService.registerEvent(registerDto);
+
+    // then
+    assertNotNull(result);
+    assertEquals("새로운 공연", result.getTitle());
+    assertEquals(EventStatus.PENDING, result.getStatus());
+    verify(eventRepository).save(any(Event.class));
+    verify(eventScheduleRepository).save(any());
+    verify(priceRepository, times(2)).save(any());
+  }
+
+  @Test
+  @DisplayName("EventEditTest - 공연 수정 성공")
+  void updateEvent_Success() {
+    // given
+    EventUpdateDto updateDto = EventUpdateDto.builder().eventId(validEventId).title("수정된 공연")
+        .ageLimit(15L).description("수정된 공연 설명").genre("연극")
+        .thumbnailUrl("https://example.com/updated-image.jpg").status(EventStatus.APPROVED).build();
+
+    Event existingEvent = Event.builder().eventId(validEventId).accountId(validAccountId)
+        .title("기존 공연").status(EventStatus.PENDING).build();
+
+    when(eventRepository.findById(validEventId)).thenReturn(existingEvent);
+    when(eventRepository.updateEvent(any(Event.class))).thenReturn(1);
+
+    // when
+    EventResponseDto result = eventService.updateEvent(updateDto);
+
+    // then
+    assertNotNull(result);
+    assertEquals("수정된 공연", result.getTitle());
+    assertEquals(EventStatus.APPROVED, result.getStatus());
+    verify(eventRepository).findById(validEventId);
+    verify(eventRepository).updateEvent(any(Event.class));
+  }
+}


### PR DESCRIPTION
## ✏️ 작업 개요  

테넌트별 이벤트 관리 기능을 위한 4개 API를 구현.
테넌트가 자신이 등록한 이벤트를 조회하고 관리할 수 있는 기능을 추가.

// 테넌트별 공연 목록 조회 => TenantEventListTest
`GET /event/api/events/tenant?account_id={accountId}`

// 테넌트별 공연 상세 조회  TenantEventDetailTest
`GET /event/api/events/tenant/{eventId}/detail?account_id={accountId}`

// 공연 등록 EventRegistTest
`POST /event/api/events?account_id={accountId}`

// 공연 수정 EventEditTest
`PUT /event/api/events/{eventId}?account_id={accountId}`


## 🔨 작업 내용 상세
- 테넌트별 공연 목록 및 상세 조회 API를 추가하고, 기존 공연 등록/수정 API에 account_id 파라미터를 반영해 기능을 확장.
- 이를 위해 컨트롤러, 서비스, 레포지토리 계층과 MyBatis 매퍼, DTO 클래스가 새롭게 추가되거나 수정.
- 각 기능에 대한 단위 테스트 클래스도 별도로 구성해 API 동작을 검증할 수 있도록 구현

## 🔗 관련 이슈  
- Closes #54 

## ✅ 체크리스트  
- [x] 테스트 코드 작성 완료
- [x] 로컬에서 기능 정상 작동 확인
- [ ] Swagger UI에서 API 확인 완료
- [ ] 예외 처리 및 ResponseDto 적용
- [ ] 공통 모듈(공통 DTO, Exception 등) 사용 지침 준수
- [ ] Google Java Style Guide 및 네이밍 규칙 준수
- [ ] Flyway 마이그레이션 파일 작성 (필요 시)


## 💬 기타 참고 사항  

```
# Service 테스트 실행
./gradlew test --tests TenantEventManagementServiceTest

# Controller 테스트 실행  
./gradlew test --tests TenantEventManagementControllerTest

# 모든 테스트 실행
./gradlew test
```