### PR TITLE
[Feature/pyokemon-133] 예매 kafka

### DIFF
--- a/booking/build.gradle
+++ b/booking/build.gradle
@@ -5,12 +5,19 @@ dependencies {
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+    
     // Database
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'org.postgresql:postgresql'
     
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testImplementation 'org.testcontainers:testcontainers:1.19.3'
+    testImplementation 'org.testcontainers:kafka:1.19.3'
+    testImplementation 'org.testcontainers:junit-jupiter:1.19.3'
 }
 
 tasks.named('test') {

--- a/booking/src/main/java/com/pyokemon/booking/BookingApplication.java
+++ b/booking/src/main/java/com/pyokemon/booking/BookingApplication.java
@@ -3,11 +3,13 @@ package com.pyokemon.booking;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = {"com.pyokemon"})
 @MapperScan("com.pyokemon.booking.repository")
 @EnableScheduling
+@EnableKafka
 public class BookingApplication {
   public static void main(String[] args) {
 

--- a/booking/src/main/java/com/pyokemon/booking/dto/PaymentEventDto.java
+++ b/booking/src/main/java/com/pyokemon/booking/dto/PaymentEventDto.java
@@ -1,0 +1,24 @@
+package com.pyokemon.booking.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentEventDto {
+    
+    @JsonProperty("payment_id")
+    private Long paymentId;
+    
+    @JsonProperty("booking_id")
+    private Long bookingId;
+    
+    @JsonProperty("order_id")
+    private String orderId;
+    
+    @JsonProperty("status")
+    private String status;
+}

--- a/booking/src/main/java/com/pyokemon/booking/dto/kafka/BookingEventDto.java
+++ b/booking/src/main/java/com/pyokemon/booking/dto/kafka/BookingEventDto.java
@@ -1,0 +1,27 @@
+package com.pyokemon.booking.dto.kafka;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookingEventDto {
+    
+    @JsonProperty("booking_id")
+    private Long bookingId;
+    
+    @JsonProperty("event_schedule_id")
+    private Long eventScheduleId;
+    
+    @JsonProperty("account_id")
+    private Long accountId;
+    
+    @JsonProperty("status")
+    private String status;
+
+}

--- a/booking/src/main/java/com/pyokemon/booking/dto/kafka/PaymentEventDto.java
+++ b/booking/src/main/java/com/pyokemon/booking/dto/kafka/PaymentEventDto.java
@@ -1,4 +1,4 @@
-package com.pyokemon.booking.dto;
+package com.pyokemon.booking.dto.kafka;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -15,10 +15,7 @@ public class PaymentEventDto {
     
     @JsonProperty("booking_id")
     private Long bookingId;
-    
-    @JsonProperty("order_id")
-    private String orderId;
-    
+
     @JsonProperty("status")
     private String status;
 }

--- a/booking/src/main/java/com/pyokemon/booking/entity/Booking.java
+++ b/booking/src/main/java/com/pyokemon/booking/entity/Booking.java
@@ -14,12 +14,13 @@ public class Booking {
   private Long eventScheduleId;
   private Long seatId;
   private Long accountId;
+  private Long tenantId;
   private Long paymentId;
   private Booked status;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 
   public enum Booked {
-    PENDING, BOOKED, CANCELLED
+    PENDING, BOOKED, CANCELED, FAILED
   }
 }

--- a/booking/src/main/java/com/pyokemon/booking/listener/PaymentEventListener.java
+++ b/booking/src/main/java/com/pyokemon/booking/listener/PaymentEventListener.java
@@ -1,0 +1,43 @@
+package com.pyokemon.booking.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pyokemon.booking.dto.PaymentEventDto;
+import com.pyokemon.booking.entity.Booking;
+import com.pyokemon.booking.service.BookingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentEventListener {
+
+    private final BookingService bookingService;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "payment-status-updated", groupId = "booking-service")
+    public void handlePaymentStatusUpdate(String message) {
+        try {
+            PaymentEventDto paymentEvent = objectMapper.readValue(message, PaymentEventDto.class);
+            Booking.Booked newStatus = mapPaymentStatusToBookingStatus(paymentEvent.getStatus());
+                
+            bookingService.updateBookingStatusAndPaymentId(paymentEvent.getBookingId(), newStatus, paymentEvent.getPaymentId());
+        } catch (Exception e) {
+            log.error("Error processing payment status update message: {}", message, e);
+        }
+    }
+
+    private Booking.Booked mapPaymentStatusToBookingStatus(String paymentStatus) {
+        return switch (paymentStatus.toUpperCase()) {
+            case "DONE" -> Booking.Booked.BOOKED;
+            case "CANCELED" -> Booking.Booked.CANCELED;
+            case "FAILED" -> Booking.Booked.FAILED;
+            default -> {
+                log.warn("Unknown payment status: {}, defaulting to FAILED", paymentStatus);
+                yield Booking.Booked.FAILED;
+            }
+        };
+    }
+}

--- a/booking/src/main/java/com/pyokemon/booking/listener/PaymentEventListener.java
+++ b/booking/src/main/java/com/pyokemon/booking/listener/PaymentEventListener.java
@@ -23,7 +23,7 @@ public class PaymentEventListener {
             PaymentEventDto paymentEvent = objectMapper.readValue(message, PaymentEventDto.class);
             Booking.Booked newStatus = mapPaymentStatusToBookingStatus(paymentEvent.getStatus());
                 
-            bookingService.updateBookingStatusAndPaymentId(paymentEvent.getBookingId(), newStatus, paymentEvent.getPaymentId());
+            bookingService.updateBookingStatus(paymentEvent.getBookingId(), newStatus, paymentEvent.getPaymentId());
         } catch (Exception e) {
             log.error("Error processing payment status update message: {}", message, e);
         }

--- a/booking/src/main/java/com/pyokemon/booking/listener/PaymentEventListener.java
+++ b/booking/src/main/java/com/pyokemon/booking/listener/PaymentEventListener.java
@@ -1,7 +1,7 @@
 package com.pyokemon.booking.listener;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.pyokemon.booking.dto.PaymentEventDto;
+import com.pyokemon.booking.dto.kafka.PaymentEventDto;
 import com.pyokemon.booking.entity.Booking;
 import com.pyokemon.booking.service.BookingService;
 import lombok.RequiredArgsConstructor;

--- a/booking/src/main/java/com/pyokemon/booking/repository/BookingRepository.java
+++ b/booking/src/main/java/com/pyokemon/booking/repository/BookingRepository.java
@@ -14,6 +14,7 @@ public interface BookingRepository {
     List<Booking> findByAccountId(@Param("accountId") Long accountId);
     List<Booking> findAllByEventScheduleIdAndSeatId(@Param("eventScheduleId") Long eventScheduleId, @Param("seatId") Long seatId);
     Optional<Booking> findActiveBookingByEventScheduleIdAndAccountId(@Param("eventScheduleId") Long eventScheduleId, @Param("accountId") Long accountId);
+    Optional<Booking> findById(@Param("bookingId") Long bookingId);
     List<Booking> findPendingBookings();
     
     void save(Booking booking);

--- a/booking/src/main/java/com/pyokemon/booking/service/BookingEventPublisher.java
+++ b/booking/src/main/java/com/pyokemon/booking/service/BookingEventPublisher.java
@@ -1,0 +1,38 @@
+package com.pyokemon.booking.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pyokemon.booking.dto.kafka.BookingEventDto;
+import com.pyokemon.booking.entity.Booking;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BookingEventPublisher {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+    
+    private static final String TOPIC = "booking-status-updated";
+
+    public void publishBookingStatusUpdate(Booking booking) {
+        try {
+            BookingEventDto event = BookingEventDto.builder()
+                    .bookingId(booking.getBookingId())
+                    .eventScheduleId(booking.getEventScheduleId())
+                    .accountId(booking.getAccountId())
+                    .status(booking.getStatus().name())
+                    .build();
+
+            String message = objectMapper.writeValueAsString(event);
+            kafkaTemplate.send(TOPIC, message);
+
+            log.info("Published booking status update event: {}", message);
+        } catch (Exception e) {
+            log.error("Failed to publish booking status update event for booking: {}", booking.getBookingId(), e);
+        }
+    }
+}

--- a/booking/src/main/java/com/pyokemon/booking/service/BookingService.java
+++ b/booking/src/main/java/com/pyokemon/booking/service/BookingService.java
@@ -90,11 +90,7 @@ public class BookingService {
                 Booking userBooking = activeBooking.get();
                 
                 if (userBooking.getSeatId().equals(request.getSeatId())) {
-                    userBooking.setStatus(Booking.Booked.CANCELED);
-                    userBooking.setUpdatedAt(LocalDateTime.now());
-                    bookingRepository.update(userBooking);
-                    
-                    bookingEventPublisher.publishBookingStatusUpdate(userBooking);
+                    updateBookingStatus(userBooking.getBookingId(), Booking.Booked.CANCELED, null);
                     
                     return new BookingResponse(userBooking.getEventScheduleId(), userBooking.getBookingId());
                 } else {
@@ -166,7 +162,7 @@ public class BookingService {
     }
     
     @Transactional
-    public void updateBookingStatus(Long bookingId, Booking.Booked status) {
+    public void updateBookingStatus(Long bookingId, Booking.Booked status, Long paymentId) {
         try {
             if (bookingId == null) {
                 throw new BusinessException("예약 ID가 필요합니다.", "INVALID_BOOKING_ID");
@@ -182,35 +178,9 @@ public class BookingService {
             
             Booking booking = bookingOpt.get();
             booking.setStatus(status);
-            booking.setUpdatedAt(LocalDateTime.now());
-            bookingRepository.update(booking);
-        
-            bookingEventPublisher.publishBookingStatusUpdate(booking);
-        } catch (BusinessException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new BusinessException("예약 상태를 업데이트할 수 없습니다.", "BOOKING_STATUS_UPDATE_ERROR");
-        }
-    }
-    
-    @Transactional
-    public void updateBookingStatusAndPaymentId(Long bookingId, Booking.Booked status, Long paymentId) {
-        try {
-            if (bookingId == null) {
-                throw new BusinessException("예약 ID가 필요합니다.", "INVALID_BOOKING_ID");
+            if (paymentId != null) {
+                booking.setPaymentId(paymentId);
             }
-            if (status == null) {
-                throw new BusinessException("상태가 필요합니다.", "INVALID_STATUS");
-            }
-            
-            Optional<Booking> bookingOpt = bookingRepository.findById(bookingId);
-            if (bookingOpt.isEmpty()) {
-                throw new BusinessException("예약을 찾을 수 없습니다.", "BOOKING_NOT_FOUND");
-            }
-            
-            Booking booking = bookingOpt.get();
-            booking.setStatus(status);
-            booking.setPaymentId(paymentId);
             booking.setUpdatedAt(LocalDateTime.now());
             bookingRepository.update(booking);
 
@@ -218,7 +188,7 @@ public class BookingService {
         } catch (BusinessException e) {
             throw e;
         } catch (Exception e) {
-            throw new BusinessException("예약 상태 및 결제 ID를 업데이트할 수 없습니다.", "BOOKING_STATUS_PAYMENT_UPDATE_ERROR");
+            throw new BusinessException("예약 상태를 업데이트할 수 없습니다.", "BOOKING_STATUS_UPDATE_ERROR");
         }
     }
 }

--- a/booking/src/main/java/com/pyokemon/booking/service/BookingService.java
+++ b/booking/src/main/java/com/pyokemon/booking/service/BookingService.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 public class BookingService {
     
     private final BookingRepository bookingRepository;
+    private final BookingEventPublisher bookingEventPublisher;
     
     public EventScheduleIdResponse getSeatIdsByEventScheduleId(Long eventScheduleId) {
         try {
@@ -92,6 +93,9 @@ public class BookingService {
                     userBooking.setStatus(Booking.Booked.CANCELED);
                     userBooking.setUpdatedAt(LocalDateTime.now());
                     bookingRepository.update(userBooking);
+                    
+                    bookingEventPublisher.publishBookingStatusUpdate(userBooking);
+                    
                     return new BookingResponse(userBooking.getEventScheduleId(), userBooking.getBookingId());
                 } else {
                     if (userBooking.getStatus() == Booking.Booked.PENDING) {
@@ -179,14 +183,12 @@ public class BookingService {
             Booking booking = bookingOpt.get();
             booking.setStatus(status);
             booking.setUpdatedAt(LocalDateTime.now());
-            
             bookingRepository.update(booking);
-            
-            log.info("Updated booking {} status to {}", bookingId, status);
+        
+            bookingEventPublisher.publishBookingStatusUpdate(booking);
         } catch (BusinessException e) {
             throw e;
         } catch (Exception e) {
-            log.error("예약 상태 업데이트 중 오류 발생: bookingId={}, status={}", bookingId, status, e);
             throw new BusinessException("예약 상태를 업데이트할 수 없습니다.", "BOOKING_STATUS_UPDATE_ERROR");
         }
     }
@@ -210,14 +212,12 @@ public class BookingService {
             booking.setStatus(status);
             booking.setPaymentId(paymentId);
             booking.setUpdatedAt(LocalDateTime.now());
-            
             bookingRepository.update(booking);
-            
-            log.info("Updated booking {} status to {} and paymentId to {}", bookingId, status, paymentId);
+
+            bookingEventPublisher.publishBookingStatusUpdate(booking);
         } catch (BusinessException e) {
             throw e;
         } catch (Exception e) {
-            log.error("예약 상태 및 결제 ID 업데이트 중 오류 발생: bookingId={}, status={}, paymentId={}", bookingId, status, paymentId, e);
             throw new BusinessException("예약 상태 및 결제 ID를 업데이트할 수 없습니다.", "BOOKING_STATUS_PAYMENT_UPDATE_ERROR");
         }
     }

--- a/booking/src/main/java/com/pyokemon/booking/service/BookingService.java
+++ b/booking/src/main/java/com/pyokemon/booking/service/BookingService.java
@@ -89,7 +89,7 @@ public class BookingService {
                 Booking userBooking = activeBooking.get();
                 
                 if (userBooking.getSeatId().equals(request.getSeatId())) {
-                    userBooking.setStatus(Booking.Booked.CANCELLED);
+                    userBooking.setStatus(Booking.Booked.CANCELED);
                     userBooking.setUpdatedAt(LocalDateTime.now());
                     bookingRepository.update(userBooking);
                     return new BookingResponse(userBooking.getEventScheduleId(), userBooking.getBookingId());
@@ -158,6 +158,67 @@ public class BookingService {
             }
         } catch (Exception e) {
             log.error("PENDING 예약 삭제 작업 중 오류 발생", e);
+        }
+    }
+    
+    @Transactional
+    public void updateBookingStatus(Long bookingId, Booking.Booked status) {
+        try {
+            if (bookingId == null) {
+                throw new BusinessException("예약 ID가 필요합니다.", "INVALID_BOOKING_ID");
+            }
+            if (status == null) {
+                throw new BusinessException("상태가 필요합니다.", "INVALID_STATUS");
+            }
+            
+            Optional<Booking> bookingOpt = bookingRepository.findById(bookingId);
+            if (bookingOpt.isEmpty()) {
+                throw new BusinessException("예약을 찾을 수 없습니다.", "BOOKING_NOT_FOUND");
+            }
+            
+            Booking booking = bookingOpt.get();
+            booking.setStatus(status);
+            booking.setUpdatedAt(LocalDateTime.now());
+            
+            bookingRepository.update(booking);
+            
+            log.info("Updated booking {} status to {}", bookingId, status);
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("예약 상태 업데이트 중 오류 발생: bookingId={}, status={}", bookingId, status, e);
+            throw new BusinessException("예약 상태를 업데이트할 수 없습니다.", "BOOKING_STATUS_UPDATE_ERROR");
+        }
+    }
+    
+    @Transactional
+    public void updateBookingStatusAndPaymentId(Long bookingId, Booking.Booked status, Long paymentId) {
+        try {
+            if (bookingId == null) {
+                throw new BusinessException("예약 ID가 필요합니다.", "INVALID_BOOKING_ID");
+            }
+            if (status == null) {
+                throw new BusinessException("상태가 필요합니다.", "INVALID_STATUS");
+            }
+            
+            Optional<Booking> bookingOpt = bookingRepository.findById(bookingId);
+            if (bookingOpt.isEmpty()) {
+                throw new BusinessException("예약을 찾을 수 없습니다.", "BOOKING_NOT_FOUND");
+            }
+            
+            Booking booking = bookingOpt.get();
+            booking.setStatus(status);
+            booking.setPaymentId(paymentId);
+            booking.setUpdatedAt(LocalDateTime.now());
+            
+            bookingRepository.update(booking);
+            
+            log.info("Updated booking {} status to {} and paymentId to {}", bookingId, status, paymentId);
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("예약 상태 및 결제 ID 업데이트 중 오류 발생: bookingId={}, status={}, paymentId={}", bookingId, status, paymentId, e);
+            throw new BusinessException("예약 상태 및 결제 ID를 업데이트할 수 없습니다.", "BOOKING_STATUS_PAYMENT_UPDATE_ERROR");
         }
     }
 }

--- a/booking/src/main/resources/application.yml
+++ b/booking/src/main/resources/application.yml
@@ -24,6 +24,17 @@ spring:
   flyway:
     locations: classpath:db/migration/booking
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: booking-service
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
 mybatis:
   mapper-locations: classpath:mapper/*.xml
 

--- a/booking/src/main/resources/db/migration/booking/V1_001__Create_booking_table.sql
+++ b/booking/src/main/resources/db/migration/booking/V1_001__Create_booking_table.sql
@@ -4,7 +4,7 @@ CREATE TABLE tb_booking (
     seat_id BIGINT NOT NULL,
     account_id BIGINT NOT NULL,
     payment_id BIGINT,
-    status ENUM('PENDING', 'BOOKED', 'CANCELLED') DEFAULT 'PENDING',
+    status ENUM('PENDING', 'BOOKED', 'CANCELED', 'FAILED') DEFAULT 'PENDING',
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     INDEX idx_event_schedule_id (event_schedule_id),

--- a/booking/src/main/resources/mapper/BookingMapper.xml
+++ b/booking/src/main/resources/mapper/BookingMapper.xml
@@ -33,6 +33,12 @@
         LIMIT 1
     </select>
 
+    <select id="findById" resultType="Booking">
+        SELECT booking_id, event_schedule_id, seat_id, account_id, payment_id, status, created_at, updated_at
+        FROM tb_booking
+        WHERE booking_id = #{bookingId}
+    </select>
+
     <select id="findPendingBookings" resultType="Booking">
         SELECT booking_id, event_schedule_id, seat_id, account_id, payment_id, status, created_at, updated_at
         FROM tb_booking
@@ -46,7 +52,7 @@
 
     <update id="update" parameterType="Booking">
         UPDATE tb_booking
-        SET status = #{status}, updated_at = #{updatedAt}
+        SET status = #{status}, payment_id = #{paymentId}, updated_at = #{updatedAt}
         WHERE booking_id = #{bookingId}
     </update>
 

--- a/booking/src/test/java/com/pyokemon/booking/listener/PaymentEventListenerTest.java
+++ b/booking/src/test/java/com/pyokemon/booking/listener/PaymentEventListenerTest.java
@@ -1,0 +1,89 @@
+package com.pyokemon.booking.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pyokemon.booking.dto.PaymentEventDto;
+import com.pyokemon.booking.entity.Booking;
+import com.pyokemon.booking.service.BookingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentEventListenerTest {
+
+    @Mock
+    private BookingService bookingService;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private PaymentEventListener paymentEventListener;
+
+    @Test
+    void handlePaymentStatusUpdate_Done_ShouldUpdateToBooked() throws Exception {
+        String message = "{\"payment_id\":1,\"booking_id\":1,\"order_id\":\"ORDER123\",\"status\":\"DONE\"}";
+        PaymentEventDto paymentEvent = new PaymentEventDto(1L, 1L, "ORDER123", "DONE");
+
+        when(objectMapper.readValue(message, PaymentEventDto.class)).thenReturn(paymentEvent);
+
+        paymentEventListener.handlePaymentStatusUpdate(message);
+
+        verify(bookingService).updateBookingStatusAndPaymentId(eq(1L), eq(Booking.Booked.BOOKED), eq(1L));
+    }
+
+    @Test
+    void handlePaymentStatusUpdate_Canceled_ShouldUpdateToCanceled() throws Exception {
+        String message = "{\"payment_id\":2,\"booking_id\":1,\"order_id\":\"ORDER123\",\"status\":\"CANCELED\"}";
+        PaymentEventDto paymentEvent = new PaymentEventDto(2L, 1L, "ORDER123", "CANCELED");
+
+        when(objectMapper.readValue(message, PaymentEventDto.class)).thenReturn(paymentEvent);
+
+        paymentEventListener.handlePaymentStatusUpdate(message);
+
+        verify(bookingService).updateBookingStatusAndPaymentId(eq(1L), eq(Booking.Booked.CANCELED), eq(2L));
+    }
+
+    @Test
+    void handlePaymentStatusUpdate_Failed_ShouldUpdateToFailed() throws Exception {
+        String message = "{\"payment_id\":3,\"booking_id\":1,\"order_id\":\"ORDER123\",\"status\":\"FAILED\"}";
+        PaymentEventDto paymentEvent = new PaymentEventDto(3L, 1L, "ORDER123", "FAILED");
+
+        when(objectMapper.readValue(message, PaymentEventDto.class)).thenReturn(paymentEvent);
+
+        paymentEventListener.handlePaymentStatusUpdate(message);
+
+        verify(bookingService).updateBookingStatusAndPaymentId(eq(1L), eq(Booking.Booked.FAILED), eq(3L));
+    }
+
+    @Test
+    void handlePaymentStatusUpdate_Ready_ShouldUpdateToFailed() throws Exception {
+        String message = "{\"payment_id\":4,\"booking_id\":1,\"order_id\":\"ORDER123\",\"status\":\"READY\"}";
+        PaymentEventDto paymentEvent = new PaymentEventDto(4L, 1L, "ORDER123", "READY");
+
+        when(objectMapper.readValue(message, PaymentEventDto.class)).thenReturn(paymentEvent);
+
+        paymentEventListener.handlePaymentStatusUpdate(message);
+
+        verify(bookingService).updateBookingStatusAndPaymentId(eq(1L), eq(Booking.Booked.FAILED), eq(4L));
+    }
+
+    @Test
+    void handlePaymentStatusUpdate_UnknownStatus_ShouldUpdateToFailed() throws Exception {
+        String message = "{\"payment_id\":5,\"booking_id\":1,\"order_id\":\"ORDER123\",\"status\":\"UNKNOWN\"}";
+        PaymentEventDto paymentEvent = new PaymentEventDto(5L, 1L, "ORDER123", "UNKNOWN");
+
+        when(objectMapper.readValue(message, PaymentEventDto.class)).thenReturn(paymentEvent);
+
+        paymentEventListener.handlePaymentStatusUpdate(message);
+
+        verify(bookingService).updateBookingStatusAndPaymentId(eq(1L), eq(Booking.Booked.FAILED), eq(5L));
+    }
+}

--- a/booking/src/test/java/com/pyokemon/booking/listener/PaymentEventListenerTest.java
+++ b/booking/src/test/java/com/pyokemon/booking/listener/PaymentEventListenerTest.java
@@ -35,7 +35,7 @@ class PaymentEventListenerTest {
 
         paymentEventListener.handlePaymentStatusUpdate(message);
 
-        verify(bookingService).updateBookingStatusAndPaymentId(eq(1L), eq(Booking.Booked.BOOKED), eq(1L));
+        verify(bookingService).updateBookingStatus(eq(1L), eq(Booking.Booked.BOOKED), eq(1L));
     }
 
     @Test
@@ -47,7 +47,7 @@ class PaymentEventListenerTest {
 
         paymentEventListener.handlePaymentStatusUpdate(message);
 
-        verify(bookingService).updateBookingStatusAndPaymentId(eq(1L), eq(Booking.Booked.CANCELED), eq(2L));
+        verify(bookingService).updateBookingStatus(eq(1L), eq(Booking.Booked.CANCELED), eq(2L));
     }
 
     @Test
@@ -59,7 +59,7 @@ class PaymentEventListenerTest {
 
         paymentEventListener.handlePaymentStatusUpdate(message);
 
-        verify(bookingService).updateBookingStatusAndPaymentId(eq(1L), eq(Booking.Booked.FAILED), eq(3L));
+        verify(bookingService).updateBookingStatus(eq(1L), eq(Booking.Booked.FAILED), eq(3L));
     }
 
     @Test
@@ -71,6 +71,6 @@ class PaymentEventListenerTest {
 
         paymentEventListener.handlePaymentStatusUpdate(message);
 
-        verify(bookingService).updateBookingStatusAndPaymentId(eq(1L), eq(Booking.Booked.FAILED), eq(5L));
+        verify(bookingService).updateBookingStatus(eq(1L), eq(Booking.Booked.FAILED), eq(5L));
     }
 }

--- a/booking/src/test/java/com/pyokemon/booking/listener/PaymentEventListenerTest.java
+++ b/booking/src/test/java/com/pyokemon/booking/listener/PaymentEventListenerTest.java
@@ -1,19 +1,18 @@
 package com.pyokemon.booking.listener;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.pyokemon.booking.dto.PaymentEventDto;
+import com.pyokemon.booking.dto.kafka.PaymentEventDto;
 import com.pyokemon.booking.entity.Booking;
 import com.pyokemon.booking.service.BookingService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentEventListenerTest {
@@ -29,8 +28,8 @@ class PaymentEventListenerTest {
 
     @Test
     void handlePaymentStatusUpdate_Done_ShouldUpdateToBooked() throws Exception {
-        String message = "{\"payment_id\":1,\"booking_id\":1,\"order_id\":\"ORDER123\",\"status\":\"DONE\"}";
-        PaymentEventDto paymentEvent = new PaymentEventDto(1L, 1L, "ORDER123", "DONE");
+        String message = "{\"payment_id\":1,\"booking_id\":1,\"status\":\"DONE\"}";
+        PaymentEventDto paymentEvent = new PaymentEventDto(1L, 1L, "DONE");
 
         when(objectMapper.readValue(message, PaymentEventDto.class)).thenReturn(paymentEvent);
 
@@ -41,8 +40,8 @@ class PaymentEventListenerTest {
 
     @Test
     void handlePaymentStatusUpdate_Canceled_ShouldUpdateToCanceled() throws Exception {
-        String message = "{\"payment_id\":2,\"booking_id\":1,\"order_id\":\"ORDER123\",\"status\":\"CANCELED\"}";
-        PaymentEventDto paymentEvent = new PaymentEventDto(2L, 1L, "ORDER123", "CANCELED");
+        String message = "{\"payment_id\":2,\"booking_id\":1,\"status\":\"CANCELED\"}";
+        PaymentEventDto paymentEvent = new PaymentEventDto(2L, 1L, "CANCELED");
 
         when(objectMapper.readValue(message, PaymentEventDto.class)).thenReturn(paymentEvent);
 
@@ -53,8 +52,8 @@ class PaymentEventListenerTest {
 
     @Test
     void handlePaymentStatusUpdate_Failed_ShouldUpdateToFailed() throws Exception {
-        String message = "{\"payment_id\":3,\"booking_id\":1,\"order_id\":\"ORDER123\",\"status\":\"FAILED\"}";
-        PaymentEventDto paymentEvent = new PaymentEventDto(3L, 1L, "ORDER123", "FAILED");
+        String message = "{\"payment_id\":3,\"booking_id\":1,\"status\":\"FAILED\"}";
+        PaymentEventDto paymentEvent = new PaymentEventDto(3L, 1L, "FAILED");
 
         when(objectMapper.readValue(message, PaymentEventDto.class)).thenReturn(paymentEvent);
 
@@ -64,21 +63,9 @@ class PaymentEventListenerTest {
     }
 
     @Test
-    void handlePaymentStatusUpdate_Ready_ShouldUpdateToFailed() throws Exception {
-        String message = "{\"payment_id\":4,\"booking_id\":1,\"order_id\":\"ORDER123\",\"status\":\"READY\"}";
-        PaymentEventDto paymentEvent = new PaymentEventDto(4L, 1L, "ORDER123", "READY");
-
-        when(objectMapper.readValue(message, PaymentEventDto.class)).thenReturn(paymentEvent);
-
-        paymentEventListener.handlePaymentStatusUpdate(message);
-
-        verify(bookingService).updateBookingStatusAndPaymentId(eq(1L), eq(Booking.Booked.FAILED), eq(4L));
-    }
-
-    @Test
     void handlePaymentStatusUpdate_UnknownStatus_ShouldUpdateToFailed() throws Exception {
-        String message = "{\"payment_id\":5,\"booking_id\":1,\"order_id\":\"ORDER123\",\"status\":\"UNKNOWN\"}";
-        PaymentEventDto paymentEvent = new PaymentEventDto(5L, 1L, "ORDER123", "UNKNOWN");
+        String message = "{\"payment_id\":5,\"booking_id\":1,\"status\":\"UNKNOWN\"}";
+        PaymentEventDto paymentEvent = new PaymentEventDto(5L, 1L, "UNKNOWN");
 
         when(objectMapper.readValue(message, PaymentEventDto.class)).thenReturn(paymentEvent);
 

--- a/booking/src/test/java/com/pyokemon/booking/service/BookingEventPublisherTest.java
+++ b/booking/src/test/java/com/pyokemon/booking/service/BookingEventPublisherTest.java
@@ -46,54 +46,42 @@ class BookingEventPublisherTest {
 
     @Test
     void publishBookingStatusUpdate_Booked_ShouldPublishEvent() throws Exception {
-        // Given
-        String expectedMessage = "{\"booking_id\":1,\"event_schedule_id\":100,\"account_id\":200,\"payment_id\":300,\"status\":\"BOOKED\",\"message\":\"예매가 완료되었습니다\"}";
+        String expectedMessage = "{\"booking_id\":1,\"event_schedule_id\":100,\"account_id\":200,\"status\":\"BOOKED\"}";
         when(objectMapper.writeValueAsString(any(BookingEventDto.class))).thenReturn(expectedMessage);
 
-        // When
         bookingEventPublisher.publishBookingStatusUpdate(testBooking);
 
-        // Then
         verify(kafkaTemplate).send(eq("booking-status-updated"), eq(expectedMessage));
     }
 
     @Test
     void publishBookingStatusUpdate_Canceled_ShouldPublishEvent() throws Exception {
-        // Given
         testBooking.setStatus(Booking.Booked.CANCELED);
-        String expectedMessage = "{\"booking_id\":1,\"event_schedule_id\":100,\"account_id\":200,\"payment_id\":300,\"status\":\"CANCELED\",\"message\":\"예매가 취소되었습니다\"}";
+        String expectedMessage = "{\"booking_id\":1,\"event_schedule_id\":100,\"account_id\":200,\"status\":\"CANCELED\"}";
         when(objectMapper.writeValueAsString(any(BookingEventDto.class))).thenReturn(expectedMessage);
 
-        // When
         bookingEventPublisher.publishBookingStatusUpdate(testBooking);
 
-        // Then
         verify(kafkaTemplate).send(eq("booking-status-updated"), eq(expectedMessage));
     }
 
     @Test
     void publishBookingStatusUpdate_Failed_ShouldPublishEvent() throws Exception {
-        // Given
         testBooking.setStatus(Booking.Booked.FAILED);
-        String expectedMessage = "{\"booking_id\":1,\"event_schedule_id\":100,\"account_id\":200,\"payment_id\":300,\"status\":\"FAILED\",\"message\":\"예매에 실패했습니다\"}";
+        String expectedMessage = "{\"booking_id\":1,\"event_schedule_id\":100,\"account_id\":200,\"status\":\"FAILED\"}";
         when(objectMapper.writeValueAsString(any(BookingEventDto.class))).thenReturn(expectedMessage);
 
-        // When
         bookingEventPublisher.publishBookingStatusUpdate(testBooking);
 
-        // Then
         verify(kafkaTemplate).send(eq("booking-status-updated"), eq(expectedMessage));
     }
 
     @Test
     void publishBookingStatusUpdate_Pending_ShouldNotPublishEvent() throws Exception {
-        // Given
         testBooking.setStatus(Booking.Booked.PENDING);
 
-        // When
         bookingEventPublisher.publishBookingStatusUpdate(testBooking);
 
-        // Then
         verify(kafkaTemplate, never()).send(any(), any());
     }
 }

--- a/booking/src/test/java/com/pyokemon/booking/service/BookingEventPublisherTest.java
+++ b/booking/src/test/java/com/pyokemon/booking/service/BookingEventPublisherTest.java
@@ -1,0 +1,99 @@
+package com.pyokemon.booking.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pyokemon.booking.dto.kafka.BookingEventDto;
+import com.pyokemon.booking.entity.Booking;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BookingEventPublisherTest {
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private BookingEventPublisher bookingEventPublisher;
+
+    private Booking testBooking;
+
+    @BeforeEach
+    void setUp() {
+        testBooking = Booking.builder()
+                .bookingId(1L)
+                .eventScheduleId(100L)
+                .accountId(200L)
+                .paymentId(300L)
+                .status(Booking.Booked.BOOKED)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    void publishBookingStatusUpdate_Booked_ShouldPublishEvent() throws Exception {
+        // Given
+        String expectedMessage = "{\"booking_id\":1,\"event_schedule_id\":100,\"account_id\":200,\"payment_id\":300,\"status\":\"BOOKED\",\"message\":\"예매가 완료되었습니다\"}";
+        when(objectMapper.writeValueAsString(any(BookingEventDto.class))).thenReturn(expectedMessage);
+
+        // When
+        bookingEventPublisher.publishBookingStatusUpdate(testBooking);
+
+        // Then
+        verify(kafkaTemplate).send(eq("booking-status-updated"), eq(expectedMessage));
+    }
+
+    @Test
+    void publishBookingStatusUpdate_Canceled_ShouldPublishEvent() throws Exception {
+        // Given
+        testBooking.setStatus(Booking.Booked.CANCELED);
+        String expectedMessage = "{\"booking_id\":1,\"event_schedule_id\":100,\"account_id\":200,\"payment_id\":300,\"status\":\"CANCELED\",\"message\":\"예매가 취소되었습니다\"}";
+        when(objectMapper.writeValueAsString(any(BookingEventDto.class))).thenReturn(expectedMessage);
+
+        // When
+        bookingEventPublisher.publishBookingStatusUpdate(testBooking);
+
+        // Then
+        verify(kafkaTemplate).send(eq("booking-status-updated"), eq(expectedMessage));
+    }
+
+    @Test
+    void publishBookingStatusUpdate_Failed_ShouldPublishEvent() throws Exception {
+        // Given
+        testBooking.setStatus(Booking.Booked.FAILED);
+        String expectedMessage = "{\"booking_id\":1,\"event_schedule_id\":100,\"account_id\":200,\"payment_id\":300,\"status\":\"FAILED\",\"message\":\"예매에 실패했습니다\"}";
+        when(objectMapper.writeValueAsString(any(BookingEventDto.class))).thenReturn(expectedMessage);
+
+        // When
+        bookingEventPublisher.publishBookingStatusUpdate(testBooking);
+
+        // Then
+        verify(kafkaTemplate).send(eq("booking-status-updated"), eq(expectedMessage));
+    }
+
+    @Test
+    void publishBookingStatusUpdate_Pending_ShouldNotPublishEvent() throws Exception {
+        // Given
+        testBooking.setStatus(Booking.Booked.PENDING);
+
+        // When
+        bookingEventPublisher.publishBookingStatusUpdate(testBooking);
+
+        // Then
+        verify(kafkaTemplate, never()).send(any(), any());
+    }
+}


### PR DESCRIPTION
## ✏️ 작업 개요  
booking-service에서 사용하는 kafka 설정

## 🔨 작업 내용 상세
- payment-service에서 보낸 kafka sub하기 -> status 변경(BOOKED/CANCELED/FAILED)
- status 변경 후 kafka pub하기 -> bookingId, eventScheduleId, accountId, status

## 🔗 관련 이슈  
- Closes #79 

## ✅ 체크리스트  
- [x] kafka 설정
- [x] kafka sub
- [x] kafka pub
- [x] test 코드 작성

## 💬 기타 참고 사항  
- status 변경: PENDING, BOOKED, CANCELED, FAILED
- tenantId 추가
- DB 드롭했다가 실행하기~