### PR TITLE
Feature/#58/pyokemon 86 payment save

### DIFF
--- a/common/src/main/java/com/pyokemon/common/exception/code/PaymentErrorCodes.java
+++ b/common/src/main/java/com/pyokemon/common/exception/code/PaymentErrorCodes.java
@@ -1,0 +1,5 @@
+package com.pyokemon.common.exception.code;
+
+public class PaymentErrorCodes {
+    public static final String TOSS_CONFIRM_FAILED = "TOSS_CONFIRM_FAILED";
+}

--- a/common/src/main/java/com/pyokemon/common/exception/code/PaymentErrorCodes.java
+++ b/common/src/main/java/com/pyokemon/common/exception/code/PaymentErrorCodes.java
@@ -2,4 +2,5 @@ package com.pyokemon.common.exception.code;
 
 public class PaymentErrorCodes {
     public static final String TOSS_CONFIRM_FAILED = "TOSS_CONFIRM_FAILED";
+    public static final String PAYMENT_NOT_FOUND = "PAYMENT_NOT_FOUND";
 }

--- a/common/src/main/resources/application-common.yml
+++ b/common/src/main/resources/application-common.yml
@@ -22,7 +22,7 @@ logging:
   config: classpath:log4j2.yml
 
 mybatis:
-  type-aliases-package: com.pyokemon.common.entity, com.pyokemon.event.entity, com.pyokemon.event.dto, com.pyokemon.booking.entity
+  type-aliases-package: com.pyokemon.common.entity, com.pyokemon.event.entity, com.pyokemon.event.dto, com.pyokemon.booking.entity, com.pyokemon.payment.entity, com.pyokemon.paymnet.dto
   configuration:
     map-underscore-to-camel-case: true
     default-fetch-size: 100

--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -4,7 +4,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    
+
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    implementation 'org.springframework.kafka:spring-kafka'
     // Database
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'org.postgresql:postgresql'

--- a/payment/src/main/java/com/pyokemon/payment/PaymentApplication.java
+++ b/payment/src/main/java/com/pyokemon/payment/PaymentApplication.java
@@ -4,7 +4,9 @@ import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication(scanBasePackages = {"com.pyokemon"})
+@SpringBootApplication(scanBasePackages = {"com.pyokemon"},
+    exclude = {
+        org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class})
 @MapperScan("com.pyokemon.payment.repository")
 public class PaymentApplication {
   public static void main(String[] args) {

--- a/payment/src/main/java/com/pyokemon/payment/PaymentApplication.java
+++ b/payment/src/main/java/com/pyokemon/payment/PaymentApplication.java
@@ -3,10 +3,9 @@ package com.pyokemon.payment;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = {"com.pyokemon"},
-    exclude = {
-        org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class})
+@SpringBootApplication(scanBasePackages = {"com.pyokemon"})
 @MapperScan("com.pyokemon.payment.repository")
 public class PaymentApplication {
   public static void main(String[] args) {

--- a/payment/src/main/java/com/pyokemon/payment/config/TossConfig.java
+++ b/payment/src/main/java/com/pyokemon/payment/config/TossConfig.java
@@ -1,0 +1,28 @@
+package com.pyokemon.payment.config;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class TossConfig {
+
+  @Value("${toss.toss-secret-key}")
+  private String secretKey;
+
+  @Bean
+  public WebClient tossWebClient() {
+    String encoded =
+        Base64.getEncoder().encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+
+    return WebClient.builder().baseUrl("https://api.tosspayments.com/v1")
+        .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + encoded).build();
+  }
+}

--- a/payment/src/main/java/com/pyokemon/payment/controller/PaymentController.java
+++ b/payment/src/main/java/com/pyokemon/payment/controller/PaymentController.java
@@ -1,0 +1,48 @@
+package com.pyokemon.payment.controller;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.pyokemon.payment.dto.PaymentConfirmRequestDto;
+import com.pyokemon.payment.dto.PaymentConfirmResponseDto;
+import com.pyokemon.payment.dto.PaymentInitiateRequestDto;
+import com.pyokemon.payment.service.PaymentService;
+import com.pyokemon.payment.service.TossPaymentService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+  final TossPaymentService tossPaymentService;
+  final PaymentService paymentService;
+
+  // 결제 임시저장
+  @PostMapping("/initiate")
+  public ResponseEntity<Map<String, Object>> reserve(
+      @RequestBody PaymentInitiateRequestDto request) {
+    paymentService.reserve(request);
+    return ResponseEntity
+        .ok(Map.of("orderId", request.getOrderId(), "amount", request.getAmount()));
+  }
+
+  // 결제 confirm, 성공/실패 처리 (Done/Failed)
+  @PostMapping("/confirm-save")
+  public ResponseEntity<PaymentConfirmResponseDto> confirm(
+      @RequestBody PaymentConfirmRequestDto request) {
+    if (request.getPaymentKey() != null) {
+      PaymentConfirmResponseDto response = tossPaymentService.confirm(request);
+      return ResponseEntity.ok(response);
+    } else {
+      tossPaymentService.fail(request);
+      return ResponseEntity.badRequest().build();
+
+    }
+  }
+
+}

--- a/payment/src/main/java/com/pyokemon/payment/dto/PaymentConfirmRequestDto.java
+++ b/payment/src/main/java/com/pyokemon/payment/dto/PaymentConfirmRequestDto.java
@@ -1,0 +1,14 @@
+package com.pyokemon.payment.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentConfirmRequestDto {
+  private String paymentKey;
+  private String orderId;
+  private int amount;
+  private String method;
+}

--- a/payment/src/main/java/com/pyokemon/payment/dto/PaymentConfirmResponseDto.java
+++ b/payment/src/main/java/com/pyokemon/payment/dto/PaymentConfirmResponseDto.java
@@ -1,0 +1,25 @@
+package com.pyokemon.payment.dto;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+import com.pyokemon.payment.entity.Payment;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentConfirmResponseDto {
+  private Long paymentId;
+  private Long bookingId;
+  private String orderId;
+  private String paymentKey;
+  private String method;
+  private int amount;
+  private String status;
+  private OffsetDateTime approvedAt;
+
+}

--- a/payment/src/main/java/com/pyokemon/payment/dto/PaymentDto.java
+++ b/payment/src/main/java/com/pyokemon/payment/dto/PaymentDto.java
@@ -10,6 +10,7 @@ import lombok.*;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class PaymentDto {
   private Long paymentId;
   private Long bookingId;

--- a/payment/src/main/java/com/pyokemon/payment/dto/PaymentDto.java
+++ b/payment/src/main/java/com/pyokemon/payment/dto/PaymentDto.java
@@ -1,0 +1,24 @@
+package com.pyokemon.payment.dto;
+
+import java.time.LocalDateTime;
+
+import com.pyokemon.payment.entity.Payment;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentDto {
+  private Long paymentId;
+  private Long bookingId;
+  private String orderId;
+  private String paymentKey;
+  private int amount;
+  private String method;
+  private String status;
+  private Long accountId;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+}

--- a/payment/src/main/java/com/pyokemon/payment/dto/PaymentInitiateRequestDto.java
+++ b/payment/src/main/java/com/pyokemon/payment/dto/PaymentInitiateRequestDto.java
@@ -1,0 +1,20 @@
+package com.pyokemon.payment.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentInitiateRequestDto {
+  private Long paymentId;
+  private Long bookingId;
+  private String orderId;
+  private int amount;
+  private String method;
+  private Long accountId;
+}

--- a/payment/src/main/java/com/pyokemon/payment/dto/PaymentKafkaDto.java
+++ b/payment/src/main/java/com/pyokemon/payment/dto/PaymentKafkaDto.java
@@ -1,0 +1,19 @@
+package com.pyokemon.payment.dto;
+
+
+import com.pyokemon.payment.entity.Payment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentKafkaDto {
+  private Long paymentId;
+  private Long bookingId;
+  Payment.PaymentStatus status;
+}

--- a/payment/src/main/java/com/pyokemon/payment/entity/Payment.java
+++ b/payment/src/main/java/com/pyokemon/payment/entity/Payment.java
@@ -15,18 +15,18 @@ import lombok.Setter;
 @AllArgsConstructor
 public class Payment {
 
-  private Long payment_id;
-  private Long booking_id;
-  private Long user_id;
-  private String payment_key;
+  private Long paymentId;
+  private Long bookingId;
+  private Long accountId;
+  private String paymentKey;
   private String method;
-  private Long total_price;
+  private Long amount;
   private PaymentStatus status;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 
   public enum PaymentStatus {
-    READY, IN_PROGRESS, WAITING_FOR_DEPOSIT, DONE, CANCELED, PARTIAL_CANCELED, ABORTED, EXPIRED
+    READY, DONE, CANCELED, FAILED
   }
 
 }

--- a/payment/src/main/java/com/pyokemon/payment/producer/KafkaMessageProducer.java
+++ b/payment/src/main/java/com/pyokemon/payment/producer/KafkaMessageProducer.java
@@ -1,0 +1,19 @@
+package com.pyokemon.payment.producer;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import com.pyokemon.payment.dto.PaymentKafkaDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaMessageProducer {
+
+  private final KafkaTemplate<Long, PaymentKafkaDto> kafkaTemplate;
+
+  public void sendPaymentConfirmed(PaymentKafkaDto dto) {
+    kafkaTemplate.send("payment-status-updated", dto.getPaymentId(), dto);
+  }
+}

--- a/payment/src/main/java/com/pyokemon/payment/repository/PaymentRepository.java
+++ b/payment/src/main/java/com/pyokemon/payment/repository/PaymentRepository.java
@@ -1,4 +1,17 @@
 package com.pyokemon.payment.repository;
 
+import org.apache.ibatis.annotations.Mapper;
+
+import com.pyokemon.payment.dto.PaymentDto;
+import com.pyokemon.payment.entity.Payment;
+
+@Mapper
 public interface PaymentRepository {
+  void insertInitiatePayment(PaymentDto dto);
+
+  void updatePayment(String orderId, String paymentKey, String status, String method);
+
+  void updatePaymentFailed(String orderId, String status, String method);
+
+  Payment selectByOrderId(String orderId);
 }

--- a/payment/src/main/java/com/pyokemon/payment/service/PaymentService.java
+++ b/payment/src/main/java/com/pyokemon/payment/service/PaymentService.java
@@ -1,0 +1,34 @@
+package com.pyokemon.payment.service;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import com.pyokemon.payment.dto.PaymentDto;
+import com.pyokemon.payment.dto.PaymentInitiateRequestDto;
+import com.pyokemon.payment.dto.PaymentKafkaDto;
+import com.pyokemon.payment.producer.KafkaMessageProducer;
+import com.pyokemon.payment.repository.PaymentRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+  final PaymentRepository paymentRepository;
+
+  public void reserve(PaymentInitiateRequestDto request) {
+    PaymentDto dto = new PaymentDto();
+    dto.setBookingId(request.getBookingId());
+    dto.setOrderId(request.getOrderId());
+    dto.setAmount(request.getAmount());
+    dto.setMethod(request.getMethod());
+    dto.setStatus("READY");
+    dto.setAccountId(request.getAccountId());
+
+    paymentRepository.insertInitiatePayment(dto);
+
+
+  }
+}

--- a/payment/src/main/java/com/pyokemon/payment/service/PaymentService.java
+++ b/payment/src/main/java/com/pyokemon/payment/service/PaymentService.java
@@ -19,13 +19,14 @@ public class PaymentService {
   final PaymentRepository paymentRepository;
 
   public void reserve(PaymentInitiateRequestDto request) {
-    PaymentDto dto = new PaymentDto();
-    dto.setBookingId(request.getBookingId());
-    dto.setOrderId(request.getOrderId());
-    dto.setAmount(request.getAmount());
-    dto.setMethod(request.getMethod());
-    dto.setStatus("READY");
-    dto.setAccountId(request.getAccountId());
+    PaymentDto dto = PaymentDto.builder()
+      .bookingId(request.getBookingId())
+      .orderId(request.getOrderId())
+      .amount(request.getAmount())
+      .method(request.getMethod())
+      .status("READY")
+      .accountId(request.getAccountId())
+            .build();
 
     paymentRepository.insertInitiatePayment(dto);
 

--- a/payment/src/main/java/com/pyokemon/payment/service/TossPaymentService.java
+++ b/payment/src/main/java/com/pyokemon/payment/service/TossPaymentService.java
@@ -1,6 +1,10 @@
 package com.pyokemon.payment.service;
 
 
+import com.pyokemon.common.exception.BusinessException;
+import com.pyokemon.common.exception.code.PaymentErrorCodes;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -11,8 +15,9 @@ import com.pyokemon.payment.producer.KafkaMessageProducer;
 import com.pyokemon.payment.repository.PaymentRepository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.servlet.View;
 import reactor.core.publisher.Mono;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TossPaymentService {
@@ -27,13 +32,15 @@ public class TossPaymentService {
     boolean markedDone = false;
     try {
       dto = tossWebClient.post().uri("/payments/confirm").bodyValue(request)
-          .exchangeToMono(response -> {
-            if (response.statusCode().isError()) {
-              return response.bodyToMono(String.class)
-                  .doOnNext(error -> System.out.println("에러: " + error))
-                  .then(Mono.error(new RuntimeException("Toss confirm failed")));
+          .exchangeToMono(res -> {
+            if (res.statusCode().isError()) {
+              final HttpStatusCode s = res.statusCode();
+              return res.bodyToMono(String.class).flatMap(body -> {
+                log.error("Toss confirm error: {}", body);
+                  return Mono.error(new BusinessException("Toss confirm failed", PaymentErrorCodes.TOSS_CONFIRM_FAILED));
+              });
             }
-            return response.bodyToMono(PaymentConfirmResponseDto.class);
+            return res.bodyToMono(PaymentConfirmResponseDto.class);
           }).block();
 
       paymentRepository.updatePayment(request.getOrderId(), request.getPaymentKey(), "DONE",

--- a/payment/src/main/java/com/pyokemon/payment/service/TossPaymentService.java
+++ b/payment/src/main/java/com/pyokemon/payment/service/TossPaymentService.java
@@ -35,7 +35,6 @@ public class TossPaymentService {
       dto = tossWebClient.post().uri("/payments/confirm").bodyValue(request)
           .exchangeToMono(res -> {
             if (res.statusCode().isError()) {
-              final HttpStatusCode s = res.statusCode();
               return res.bodyToMono(String.class).flatMap(body -> {
                 log.error("Toss confirm error: {}", body);
                   return Mono.error(new BusinessException("Toss confirm failed", PaymentErrorCodes.TOSS_CONFIRM_FAILED));
@@ -49,6 +48,12 @@ public class TossPaymentService {
 
       );
       var p = paymentRepository.selectByOrderId(request.getOrderId());
+      if(p==null) {
+        log.error("Payment {} not found.", request.getOrderId());
+        throw new BusinessException(
+              "Payment not found.", PaymentErrorCodes.PAYMENT_NOT_FOUND
+        );
+      }
       PaymentKafkaDto kafkaDto =
           new PaymentKafkaDto(p.getPaymentId(), p.getBookingId(), p.getStatus());
       kafkaMessageProducer.sendPaymentConfirmed(kafkaDto);
@@ -56,9 +61,17 @@ public class TossPaymentService {
       return dto;
 
     } catch (Exception e) {
+      log.error("Confirm failed: type={}, msg={}", e.getClass().getName(), e.getMessage(), e);
+
       if (!markedDone) {
         paymentRepository.updatePaymentFailed(request.getOrderId(), "FAILED", null);
         var p = paymentRepository.selectByOrderId(request.getOrderId());
+        if(p==null) {
+          log.error("Payment {} not found.", request.getOrderId());
+          throw new BusinessException(
+                  "Payment not found.", PaymentErrorCodes.PAYMENT_NOT_FOUND
+          );
+        }
         PaymentKafkaDto kafkaDto =
             new PaymentKafkaDto(p.getPaymentId(), p.getBookingId(), p.getStatus());
         kafkaMessageProducer.sendPaymentConfirmed(kafkaDto);
@@ -67,12 +80,18 @@ public class TossPaymentService {
     }
 
   }
-  
+
   @Transactional
   public void fail(PaymentConfirmRequestDto request) {
     paymentRepository.updatePaymentFailed(request.getOrderId(), "FAILED", null);
 
     var p = paymentRepository.selectByOrderId(request.getOrderId());
+    if(p==null) {
+      log.error("Payment {} not found.", request.getOrderId());
+      throw new BusinessException(
+              "Payment not found.", PaymentErrorCodes.PAYMENT_NOT_FOUND
+      );
+    }
     PaymentKafkaDto kafkaDto =
         new PaymentKafkaDto(p.getPaymentId(), p.getBookingId(), p.getStatus());
     kafkaMessageProducer.sendPaymentConfirmed(kafkaDto);

--- a/payment/src/main/java/com/pyokemon/payment/service/TossPaymentService.java
+++ b/payment/src/main/java/com/pyokemon/payment/service/TossPaymentService.java
@@ -1,0 +1,72 @@
+package com.pyokemon.payment.service;
+
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.pyokemon.payment.dto.PaymentConfirmRequestDto;
+import com.pyokemon.payment.dto.PaymentConfirmResponseDto;
+import com.pyokemon.payment.dto.PaymentKafkaDto;
+import com.pyokemon.payment.producer.KafkaMessageProducer;
+import com.pyokemon.payment.repository.PaymentRepository;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class TossPaymentService {
+
+  private final PaymentRepository paymentRepository;
+
+  private final WebClient tossWebClient;
+  private final KafkaMessageProducer kafkaMessageProducer;
+
+  public PaymentConfirmResponseDto confirm(PaymentConfirmRequestDto request) {
+    PaymentConfirmResponseDto dto = null;
+    boolean markedDone = false;
+    try {
+      dto = tossWebClient.post().uri("/payments/confirm").bodyValue(request)
+          .exchangeToMono(response -> {
+            if (response.statusCode().isError()) {
+              return response.bodyToMono(String.class)
+                  .doOnNext(error -> System.out.println("에러: " + error))
+                  .then(Mono.error(new RuntimeException("Toss confirm failed")));
+            }
+            return response.bodyToMono(PaymentConfirmResponseDto.class);
+          }).block();
+
+      paymentRepository.updatePayment(request.getOrderId(), request.getPaymentKey(), "DONE",
+          dto.getMethod()
+
+      );
+      var p = paymentRepository.selectByOrderId(request.getOrderId());
+      PaymentKafkaDto kafkaDto =
+          new PaymentKafkaDto(p.getPaymentId(), p.getBookingId(), p.getStatus());
+      kafkaMessageProducer.sendPaymentConfirmed(kafkaDto);
+      markedDone = true;
+      return dto;
+
+    } catch (Exception e) {
+      if (!markedDone) {
+        paymentRepository.updatePaymentFailed(request.getOrderId(), "FAILED", null);
+        var p = paymentRepository.selectByOrderId(request.getOrderId());
+        PaymentKafkaDto kafkaDto =
+            new PaymentKafkaDto(p.getPaymentId(), p.getBookingId(), p.getStatus());
+        kafkaMessageProducer.sendPaymentConfirmed(kafkaDto);
+      }
+      throw e;
+    }
+
+  }
+
+  public void fail(PaymentConfirmRequestDto request) {
+    paymentRepository.updatePaymentFailed(request.getOrderId(), "FAILED", null);
+
+    var p = paymentRepository.selectByOrderId(request.getOrderId());
+    PaymentKafkaDto kafkaDto =
+        new PaymentKafkaDto(p.getPaymentId(), p.getBookingId(), p.getStatus());
+    kafkaMessageProducer.sendPaymentConfirmed(kafkaDto);
+  }
+
+}

--- a/payment/src/main/java/com/pyokemon/payment/service/TossPaymentService.java
+++ b/payment/src/main/java/com/pyokemon/payment/service/TossPaymentService.java
@@ -6,6 +6,7 @@ import com.pyokemon.common.exception.code.PaymentErrorCodes;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import com.pyokemon.payment.dto.PaymentConfirmRequestDto;
@@ -66,7 +67,8 @@ public class TossPaymentService {
     }
 
   }
-
+  
+  @Transactional
   public void fail(PaymentConfirmRequestDto request) {
     paymentRepository.updatePaymentFailed(request.getOrderId(), "FAILED", null);
 

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -24,6 +24,26 @@ spring:
   flyway:
     locations: classpath:db/migration/payment
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    listener:
+      ack-mode: manual_immediate
+    consumer:
+      group-id: ${spring.application.name}
+      key-deserializer: org.apache.kafka.common.serialization.LongDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      enable-auto-commit: false
+      auto-offset-reset: latest
+      max-poll-records: 10
+      properties:
+        spring.json.trusted.packages: "*"
+        spring.json.use.type.headers: false  # 헤더의 타입 정보 무시
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.LongSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false  # 타입
+
 mybatis:
   mapper-locations: classpath:mapper/*.xml
   type-aliases-package: com.pyokemon.payment.entity
@@ -31,6 +51,9 @@ mybatis:
     map-underscore-to-camel-case: true
     default-fetch-size: 100
     default-statement-timeout: 30
+
+toss:
+  toss-secret-key: 
 
 
 ---

--- a/payment/src/main/resources/db/migration/payment/V1_001__Create_payment_table.sql
+++ b/payment/src/main/resources/db/migration/payment/V1_001__Create_payment_table.sql
@@ -2,15 +2,13 @@
 CREATE TABLE tb_payment (
         payment_id     BIGINT AUTO_INCREMENT PRIMARY KEY,
         booking_id     BIGINT NOT NULL,
-        user_id        BIGINT NOT NULL,
-        payment_key    VARCHAR(255) NOT NULL,
+        account_id     BIGINT NOT NULL,
+        order_id       VARCHAR(255),
+        payment_key    VARCHAR(255),
         method         VARCHAR(50) NOT NULL,
-        total_price    INT NOT NULL,
-        status         ENUM('READY', 'IN_PROGRESS', 'WAITING_FOR_DEPOSIT', 'DONE', 'CANCELED', 'PARTIAL_CANCELED', 'ABORTED', 'EXPIRED') NOT NULL DEFAULT 'READY',
+        amount         INT NOT NULL,
+        status         ENUM('READY', 'DONE', 'CANCELED', 'FAILED') NOT NULL DEFAULT 'READY',
         created_at     DATETIME DEFAULT CURRENT_TIMESTAMP,
         updated_at     DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
-CREATE INDEX idx_payment_booking_id ON tb_payment(booking_id);
-CREATE INDEX idx_payment_user_id ON tb_payment(user_id);

--- a/payment/src/main/resources/mapper/PaymentMapper.xml
+++ b/payment/src/main/resources/mapper/PaymentMapper.xml
@@ -5,16 +5,31 @@
 
 <mapper namespace="com.pyokemon.payment.repository.PaymentRepository">
 
-    <resultMap id="paymentResultMap" type="Payment">
-        <id property="id" column="id"/>
-        <result property="booking_id" column="booking_id"/>
-        <result property="user_id" column="user_id"/>
-        <result property="payment_key" column="payment_key"/>
-        <result property="method" column="method"/>
-        <result property="total_price" column="total_price"/>
-        <result property="status" column="status"/>
-        <result property="createdAt" column="createdAt"/>
-        <result property="updatedAt" column="updated_at"/>
-    </resultMap>
+    <insert id="insertInitiatePayment" parameterType="com.pyokemon.payment.dto.PaymentDto" useGeneratedKeys="true" keyProperty="paymentId">
+        INSERT INTO tb_payment (
+            booking_id, order_id, amount, method, status, account_id
+        ) VALUES (
+                     #{bookingId}, #{orderId}, #{amount}, #{method}, #{status}, #{accountId}
+                 )
+    </insert>
 
-</mapper> 
+    <update id="updatePayment" parameterType="com.pyokemon.payment.dto.PaymentConfirmRequestDto">
+        UPDATE tb_payment
+        SET payment_key = #{paymentKey}, status = #{status}, method = #{method}, created_at = NOW()
+        WHERE order_id = #{orderId}
+    </update>
+
+    <update id="updatePaymentFailed">
+        UPDATE tb_payment
+        SET status = #{status}, updated_at = NOW()
+        WHERE order_id = #{orderId}
+    </update>
+
+    <select id="selectByOrderId" parameterType="string" resultType="Payment">
+        SELECT payment_id, booking_id, payment_key, status
+        FROM tb_payment
+        WHERE order_id = #{orderId}
+    </select>
+
+
+</mapper>

--- a/payment/src/test/java/com/pyokemon/payment/service/PaymentServiceTest.java
+++ b/payment/src/test/java/com/pyokemon/payment/service/PaymentServiceTest.java
@@ -1,0 +1,50 @@
+package com.pyokemon.payment.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.pyokemon.payment.dto.PaymentDto;
+import com.pyokemon.payment.dto.PaymentInitiateRequestDto;
+import com.pyokemon.payment.repository.PaymentRepository;
+
+class PaymentServiceTest {
+
+  private PaymentRepository paymentRepository;
+  private PaymentService paymentService;
+
+  @BeforeEach
+  void setUp() {
+    paymentRepository = mock(PaymentRepository.class);
+    paymentService = new PaymentService(paymentRepository);
+  }
+
+  @Test
+  void reserve_shouldSavePaymentWithCorrectData() {
+    // given
+    PaymentInitiateRequestDto request = new PaymentInitiateRequestDto();
+    request.setBookingId(1L);
+    request.setOrderId("ORDER-123");
+    request.setAmount(5000);
+    request.setMethod("간편결제");
+    request.setAccountId(42L);
+
+    // when
+    paymentService.reserve(request);
+
+    // then
+    ArgumentCaptor<PaymentDto> captor = ArgumentCaptor.forClass(PaymentDto.class);
+    verify(paymentRepository, times(1)).insertInitiatePayment(captor.capture());
+
+    PaymentDto saved = captor.getValue();
+    assertEquals(1L, saved.getBookingId());
+    assertEquals("ORDER-123", saved.getOrderId());
+    assertEquals(5000, saved.getAmount());
+    assertEquals("간편결제", saved.getMethod());
+    assertEquals("READY", saved.getStatus());
+    assertEquals(42L, saved.getAccountId());
+  }
+}

--- a/payment/src/test/java/com/pyokemon/payment/service/TossPaymentServiceTest.java
+++ b/payment/src/test/java/com/pyokemon/payment/service/TossPaymentServiceTest.java
@@ -1,0 +1,147 @@
+// src/test/java/com/pyokemon/payment/service/TossPaymentServiceTest.java
+package com.pyokemon.payment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.pyokemon.payment.dto.PaymentConfirmRequestDto;
+import com.pyokemon.payment.dto.PaymentConfirmResponseDto;
+import com.pyokemon.payment.dto.PaymentKafkaDto;
+import com.pyokemon.payment.entity.Payment;
+import com.pyokemon.payment.entity.Payment.PaymentStatus;
+import com.pyokemon.payment.producer.KafkaMessageProducer;
+import com.pyokemon.payment.repository.PaymentRepository;
+
+import reactor.core.publisher.Mono;
+
+@ExtendWith(MockitoExtension.class)
+class TossPaymentServiceTest {
+
+  @Mock
+  PaymentRepository paymentRepository;
+
+  @Mock
+  KafkaMessageProducer kafkaMessageProducer;
+
+  // ✅ Deep stubs로 체인 한 줄 스텁
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  WebClient webClient;
+
+  @InjectMocks
+  TossPaymentService tossPaymentService;
+
+  // ====== 성공 케이스 ======
+  @Test
+  void confirm_success_updatesPayment_sendsKafka_returnsDto() {
+    // given
+    PaymentConfirmRequestDto req = new PaymentConfirmRequestDto();
+    set(req, "orderId", "ORDER_123");
+    set(req, "paymentKey", "pay_abc");
+
+    PaymentConfirmResponseDto resp = new PaymentConfirmResponseDto();
+    // 네 DTO 구조에 맞게 수정 (세터가 있으면 세터 사용)
+    set(resp, "method", "CARD");
+
+    // WebClient 체인: 성공 응답
+    when(webClient.post().uri(anyString()).bodyValue(any()).exchangeToMono(any()))
+        .thenReturn(Mono.just(resp));
+
+    // DB 재조회 결과 (Kafka payload 구성용)
+    Payment persisted =
+        Payment.builder().paymentId(100L).bookingId(200L).status(PaymentStatus.DONE).build();
+    when(paymentRepository.selectByOrderId("ORDER_123")).thenReturn(persisted);
+
+    // when
+    PaymentConfirmResponseDto result = tossPaymentService.confirm(req);
+
+    // then
+    assertThat(result).isNotNull();
+    verify(paymentRepository).updatePayment("ORDER_123", "pay_abc", "DONE", "CARD");
+    verify(paymentRepository).selectByOrderId("ORDER_123");
+
+    ArgumentCaptor<PaymentKafkaDto> captor = ArgumentCaptor.forClass(PaymentKafkaDto.class);
+    verify(kafkaMessageProducer, times(1)).sendPaymentConfirmed(captor.capture());
+
+    PaymentKafkaDto sent = captor.getValue();
+    assertThat(sent.getPaymentId()).isEqualTo(100L);
+    assertThat(sent.getBookingId()).isEqualTo(200L);
+    // status 타입이 String이면 "DONE" 비교, enum이면 생략 또는 맞게 비교
+    // 예) assertThat(sent.getStatus()).isEqualTo("DONE");
+  }
+
+  // ====== 실패 케이스(승인 실패) ======
+  @Test
+  void confirm_failure_marksFailed_sendsKafka_thenThrows() {
+    // given
+    PaymentConfirmRequestDto req = new PaymentConfirmRequestDto();
+    set(req, "orderId", "ORDER_123");
+    set(req, "paymentKey", "pay_abc");
+
+    // WebClient 체인: 실패 응답
+    when(webClient.post().uri(anyString()).bodyValue(any()).exchangeToMono(any()))
+        .thenReturn(Mono.error(new RuntimeException("Toss confirm failed")));
+
+    // 실패 후 DB 재조회 결과 (Kafka 실패 알림용)
+    Payment failedRow =
+        Payment.builder().paymentId(111L).bookingId(222L).status(PaymentStatus.FAILED).build();
+    when(paymentRepository.selectByOrderId("ORDER_123")).thenReturn(failedRow);
+
+    // when & then
+    assertThrows(RuntimeException.class, () -> tossPaymentService.confirm(req));
+
+    verify(paymentRepository).updatePaymentFailed(eq("ORDER_123"), eq("FAILED"), isNull());
+    verify(paymentRepository).selectByOrderId("ORDER_123");
+
+    ArgumentCaptor<PaymentKafkaDto> captor = ArgumentCaptor.forClass(PaymentKafkaDto.class);
+    verify(kafkaMessageProducer, times(1)).sendPaymentConfirmed(captor.capture());
+
+    PaymentKafkaDto sent = captor.getValue();
+    assertThat(sent.getPaymentId()).isEqualTo(111L);
+    assertThat(sent.getBookingId()).isEqualTo(222L);
+    // 예) assertThat(sent.getStatus()).isEqualTo("FAILED");
+  }
+
+  // ====== fail() 직접 호출 ======
+  @Test
+  void fail_marksFailed_and_sendsKafka() {
+    // given
+    PaymentConfirmRequestDto req = new PaymentConfirmRequestDto();
+    set(req, "orderId", "ORDER_999");
+
+    Payment failedRow =
+        Payment.builder().paymentId(999L).bookingId(888L).status(PaymentStatus.FAILED).build();
+    when(paymentRepository.selectByOrderId("ORDER_999")).thenReturn(failedRow);
+
+    // when
+    tossPaymentService.fail(req);
+
+    // then
+    verify(paymentRepository).updatePaymentFailed(eq("ORDER_999"), eq("FAILED"), isNull());
+    verify(paymentRepository).selectByOrderId("ORDER_999");
+
+    ArgumentCaptor<PaymentKafkaDto> captor = ArgumentCaptor.forClass(PaymentKafkaDto.class);
+    verify(kafkaMessageProducer, times(1)).sendPaymentConfirmed(captor.capture());
+
+    PaymentKafkaDto sent = captor.getValue();
+    assertThat(sent.getPaymentId()).isEqualTo(999L);
+    assertThat(sent.getBookingId()).isEqualTo(888L);
+  }
+
+  // ====== 리플렉션 유틸: 세터가 없을 때만 사용 ======
+  private static void set(Object target, String field, Object value) {
+    try {
+      var f = target.getClass().getDeclaredField(field);
+      f.setAccessible(true);
+      f.set(target, value);
+    } catch (Exception ignored) {
+    }
+  }
+}

--- a/payment/src/test/payment.postman_collection.json
+++ b/payment/src/test/payment.postman_collection.json
@@ -1,0 +1,44 @@
+{
+	"info": {
+		"_postman_id": "c04169a3-d438-4037-b39e-a36fdf7288b3",
+		"name": "payment",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "30993736"
+	},
+	"item": [
+		{
+			"name": "결제 임시 저장",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"bookingId\":\"1\",\r\n  \"orderId\": \"ORDER_17230112111123456\",\r\n  \"amount\": 15000,\r\n  \"method\": \"카드\",\r\n  \"accountId\": 1\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8086/payment/api/payments/initiate",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8086",
+					"path": [
+						"payment",
+						"api",
+						"payments",
+						"initiate"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
## ✏️ 작업 개요  
- payment 결제 임시 저장
- payment 결제 저장

## 🔨 작업 내용 상세
- 결제 임시저장, 결제 confirm, DB 저장, 카프카 전송

## 🔗 관련 이슈  
- Closes #58 

## ✅ 체크리스트  
- [ ] 테스트 코드 작성 완료
- [ ] 로컬에서 기능 정상 작동 확인
- [ ] payment entity 수정
- [ ] 결제 완료 ready -> done 변경 카프카
- [ ] 실패 ready -> failed 변경 카프카


## 💬 기타 참고 사항  
```text
src/main/java/com/pyokemon/payment/
├─ config/
│  └─ TossConfig.java                 # WebClient 설정 (baseUrl, header 등)
├─ controller/
│  └─ PaymentController.java         
├─ dto/
│  ├─ PaymentConfirmRequestDto.java
│  ├─ PaymentConfirmResponseDto.java
│  ├─ PaymentDto.java
│  ├─ PaymentInitiateRequestDto.java
│  └─ PaymentKafkaDto.java            # Kafka 전송 DTO (paymentId, bookingId, status)
├─ entity/
│  └─ Payment.java                   
├─ producer/
│  └─ KafkaMessageProducer.java       # KafkaTemplate<Long, PaymentKafkaDto> 사용
├─ repository/
│  └─ PaymentRepository.java          # updatePayment / updatePaymentFailed / selectByOrderId
├─ service/
│  ├─ PaymentService.java
│  └─ TossPaymentService.java         # 승인 호출, DB 업데이트, Kafka 발행
└─ PaymentApplication.java
```
