### PR TITLE
[Feature/pyokemon-140] 유효 예약 확인 API

### DIFF
--- a/booking/src/main/java/com/pyokemon/booking/controller/BookingController.java
+++ b/booking/src/main/java/com/pyokemon/booking/controller/BookingController.java
@@ -1,11 +1,9 @@
 package com.pyokemon.booking.controller;
 
 import com.pyokemon.booking.dto.request.BookingRequest;
-import com.pyokemon.booking.dto.request.ValidBookingRequest;
 import com.pyokemon.booking.dto.response.AccountIdResponse;
 import com.pyokemon.booking.dto.response.BookingResponse;
 import com.pyokemon.booking.dto.response.EventScheduleIdResponse;
-import com.pyokemon.booking.dto.response.ValidBookingResponse;
 import com.pyokemon.booking.service.BookingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -38,12 +36,5 @@ public class BookingController {
             @RequestHeader("X-Auth-AccountId") Long accountId) {
         BookingResponse booking = bookingService.createOrUpdateBooking(request, accountId);
         return ResponseEntity.ok(booking);
-    }
-    
-    @PostMapping("/validate")
-    public ResponseEntity<ValidBookingResponse> validateBookings(
-            @RequestBody ValidBookingRequest request) {
-        ValidBookingResponse response = bookingService.validateBookings(request);
-        return ResponseEntity.ok(response);
     }
 }

--- a/booking/src/main/java/com/pyokemon/booking/controller/BookingController.java
+++ b/booking/src/main/java/com/pyokemon/booking/controller/BookingController.java
@@ -1,9 +1,11 @@
 package com.pyokemon.booking.controller;
 
 import com.pyokemon.booking.dto.request.BookingRequest;
+import com.pyokemon.booking.dto.request.ValidBookingRequest;
 import com.pyokemon.booking.dto.response.AccountIdResponse;
 import com.pyokemon.booking.dto.response.BookingResponse;
 import com.pyokemon.booking.dto.response.EventScheduleIdResponse;
+import com.pyokemon.booking.dto.response.ValidBookingResponse;
 import com.pyokemon.booking.service.BookingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -36,5 +38,12 @@ public class BookingController {
             @RequestHeader("X-Auth-AccountId") Long accountId) {
         BookingResponse booking = bookingService.createOrUpdateBooking(request, accountId);
         return ResponseEntity.ok(booking);
+    }
+    
+    @PostMapping("/validate")
+    public ResponseEntity<ValidBookingResponse> validateBookings(
+            @RequestBody ValidBookingRequest request) {
+        ValidBookingResponse response = bookingService.validateBookings(request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/booking/src/main/java/com/pyokemon/booking/controller/BookingController.java
+++ b/booking/src/main/java/com/pyokemon/booking/controller/BookingController.java
@@ -31,10 +31,18 @@ public class BookingController {
     }
 
     @PostMapping("/booking")
-    public ResponseEntity<BookingResponse> createOrUpdateBooking(
+    public ResponseEntity<BookingResponse> createBooking(
             @RequestBody BookingRequest request,
             @RequestHeader("X-Auth-AccountId") Long accountId) {
-        BookingResponse booking = bookingService.createOrUpdateBooking(request, accountId);
+        BookingResponse booking = bookingService.createBooking(request, accountId);
         return ResponseEntity.ok(booking);
+    }
+
+    @DeleteMapping("/booking/{eventScheduleId}")
+    public ResponseEntity<Void> cancelBooking(
+            @PathVariable Long eventScheduleId,
+            @RequestHeader("X-Auth-AccountId") Long accountId) {
+        bookingService.cancelBooking(eventScheduleId, accountId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/booking/src/main/java/com/pyokemon/booking/controller/ValidBookingController.java
+++ b/booking/src/main/java/com/pyokemon/booking/controller/ValidBookingController.java
@@ -1,0 +1,26 @@
+package com.pyokemon.booking.controller;
+
+import com.pyokemon.booking.dto.request.ValidBookingRequest;
+import com.pyokemon.booking.dto.response.ValidBookingResponse;
+import com.pyokemon.booking.service.BookingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/backend")
+public class ValidBookingController {
+    
+    private final BookingService bookingService;
+    
+    @PostMapping("/validbookings")
+    public ResponseEntity<ValidBookingResponse> validateBookings(
+            @RequestBody ValidBookingRequest request) {
+        ValidBookingResponse response = bookingService.validateBookings(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/booking/src/main/java/com/pyokemon/booking/dto/request/BookingRequest.java
+++ b/booking/src/main/java/com/pyokemon/booking/dto/request/BookingRequest.java
@@ -12,4 +12,5 @@ import lombok.Setter;
 public class BookingRequest {
     private Long eventScheduleId;
     private Long seatId;
+    private Long tenantId;
 }

--- a/booking/src/main/java/com/pyokemon/booking/dto/request/ValidBookingRequest.java
+++ b/booking/src/main/java/com/pyokemon/booking/dto/request/ValidBookingRequest.java
@@ -1,0 +1,19 @@
+package com.pyokemon.booking.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ValidBookingRequest {
+    private Long userId;
+    private List<Long> bookings;
+}

--- a/booking/src/main/java/com/pyokemon/booking/dto/response/ValidBookingDetail.java
+++ b/booking/src/main/java/com/pyokemon/booking/dto/response/ValidBookingDetail.java
@@ -13,6 +13,6 @@ import lombok.Setter;
 @AllArgsConstructor
 public class ValidBookingDetail {
     private Long bookingId;
-    private Long eventId;
+    private Long eventScheduleId;
     private Long tenantId;
 }

--- a/booking/src/main/java/com/pyokemon/booking/dto/response/ValidBookingDetail.java
+++ b/booking/src/main/java/com/pyokemon/booking/dto/response/ValidBookingDetail.java
@@ -1,0 +1,18 @@
+package com.pyokemon.booking.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ValidBookingDetail {
+    private Long bookingId;
+    private Long eventId;
+    private Long tenantId;
+}

--- a/booking/src/main/java/com/pyokemon/booking/dto/response/ValidBookingResponse.java
+++ b/booking/src/main/java/com/pyokemon/booking/dto/response/ValidBookingResponse.java
@@ -1,0 +1,18 @@
+package com.pyokemon.booking.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ValidBookingResponse {
+    private List<ValidBookingDetail> bookings;
+}

--- a/booking/src/main/java/com/pyokemon/booking/repository/BookingRepository.java
+++ b/booking/src/main/java/com/pyokemon/booking/repository/BookingRepository.java
@@ -1,5 +1,6 @@
 package com.pyokemon.booking.repository;
 
+import com.pyokemon.booking.dto.response.ValidBookingDetail;
 import com.pyokemon.booking.entity.Booking;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -16,6 +17,7 @@ public interface BookingRepository {
     Optional<Booking> findActiveBookingByEventScheduleIdAndAccountId(@Param("eventScheduleId") Long eventScheduleId, @Param("accountId") Long accountId);
     Optional<Booking> findById(@Param("bookingId") Long bookingId);
     List<Booking> findPendingBookings();
+    List<ValidBookingDetail> findValidBookingsWithEventInfo(@Param("bookingIds") List<Long> bookingIds, @Param("accountId") Long accountId);
     
     void save(Booking booking);
     void update(Booking booking);

--- a/booking/src/main/java/com/pyokemon/booking/service/BookingService.java
+++ b/booking/src/main/java/com/pyokemon/booking/service/BookingService.java
@@ -1,10 +1,13 @@
 package com.pyokemon.booking.service;
 
 import com.pyokemon.booking.dto.request.BookingRequest;
+import com.pyokemon.booking.dto.request.ValidBookingRequest;
 import com.pyokemon.booking.dto.response.AccountIdResponse;
 import com.pyokemon.booking.dto.response.BookingInfo;
 import com.pyokemon.booking.dto.response.BookingResponse;
 import com.pyokemon.booking.dto.response.EventScheduleIdResponse;
+import com.pyokemon.booking.dto.response.ValidBookingDetail;
+import com.pyokemon.booking.dto.response.ValidBookingResponse;
 import com.pyokemon.booking.entity.Booking;
 import com.pyokemon.booking.repository.BookingRepository;
 import com.pyokemon.common.exception.BusinessException;
@@ -65,6 +68,28 @@ public class BookingService {
             throw e;
         } catch (Exception e) {
             throw new BusinessException("예약 정보를 조회할 수 없습니다.", "BOOKING_QUERY_ERROR");
+        }
+    }
+    
+    public ValidBookingResponse validateBookings(ValidBookingRequest request) {
+        try {
+            if (request.getUserId() == null) {
+                throw new BusinessException("사용자 ID가 필요합니다.", "INVALID_USER_ID");
+            }
+            if (request.getBookings() == null || request.getBookings().isEmpty()) {
+                throw new BusinessException("예약 ID 목록이 필요합니다.", "INVALID_BOOKING_IDS");
+            }
+            
+            List<ValidBookingDetail> validBookings = 
+                bookingRepository.findValidBookingsWithEventInfo(request.getBookings(), request.getUserId());
+            
+            return ValidBookingResponse.builder()
+                    .bookings(validBookings)
+                    .build();
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException("예약 검증을 처리할 수 없습니다.", "BOOKING_VALIDATION_ERROR");
         }
     }
     

--- a/booking/src/main/java/com/pyokemon/booking/service/BookingService.java
+++ b/booking/src/main/java/com/pyokemon/booking/service/BookingService.java
@@ -77,6 +77,9 @@ public class BookingService {
             if (request.getSeatId() == null) {
                 throw new BusinessException("좌석 ID가 필요합니다.", "INVALID_SEAT_ID");
             }
+            if (request.getTenantId() == null) {
+                throw new BusinessException("테넌트 ID가 필요합니다.", "INVALID_TENANT_ID");
+            }
             if (accountId == null) {
                 throw new BusinessException("계정 ID가 필요합니다.", "INVALID_ACCOUNT_ID");
             }
@@ -128,6 +131,7 @@ public class BookingService {
                     .eventScheduleId(request.getEventScheduleId())
                     .seatId(request.getSeatId())
                     .accountId(accountId)
+                    .tenantId(request.getTenantId())
                     .paymentId(null)
                     .status(Booking.Booked.PENDING)
                     .createdAt(LocalDateTime.now())

--- a/booking/src/main/java/com/pyokemon/booking/service/BookingService.java
+++ b/booking/src/main/java/com/pyokemon/booking/service/BookingService.java
@@ -29,7 +29,8 @@ public class BookingService {
     
     private final BookingRepository bookingRepository;
     private final BookingEventPublisher bookingEventPublisher;
-    
+
+    // eventScheduleId -> BOOKED/PENDING인 seatID 반환
     public EventScheduleIdResponse getSeatIdsByEventScheduleId(Long eventScheduleId) {
         try {
             if (eventScheduleId == null) {
@@ -44,7 +45,8 @@ public class BookingService {
             throw new BusinessException("좌석 정보를 조회할 수 없습니다.", "SEAT_QUERY_ERROR");
         }
     }
-    
+
+    // accountId -> 해당 accountId의 예매내역 반환
     public AccountIdResponse getBookingsByAccountId(Long accountId) {
         try {
             if (accountId == null) {
@@ -70,7 +72,8 @@ public class BookingService {
             throw new BusinessException("예약 정보를 조회할 수 없습니다.", "BOOKING_QUERY_ERROR");
         }
     }
-    
+
+    // accountId/bookingId -> 유효한 bookingId 반환
     public ValidBookingResponse validateBookings(ValidBookingRequest request) {
         try {
             if (request.getUserId() == null) {
@@ -92,9 +95,10 @@ public class BookingService {
             throw new BusinessException("예약 검증을 처리할 수 없습니다.", "BOOKING_VALIDATION_ERROR");
         }
     }
-    
+
+    // 예매 내역 저장
     @Transactional
-    public BookingResponse createOrUpdateBooking(BookingRequest request, Long accountId) {
+    public BookingResponse createBooking(BookingRequest request, Long accountId) {
         try {
             if (request.getEventScheduleId() == null) {
                 throw new BusinessException("이벤트 스케줄 ID가 필요합니다.", "INVALID_EVENT_SCHEDULE_ID");
@@ -116,30 +120,13 @@ public class BookingService {
             
             if (activeBooking.isPresent()) {
                 Booking userBooking = activeBooking.get();
-                
-                if (userBooking.getSeatId().equals(request.getSeatId())) {
-                    updateBookingStatus(userBooking.getBookingId(), Booking.Booked.CANCELED, null);
-                    
-                    return new BookingResponse(userBooking.getEventScheduleId(), userBooking.getBookingId());
+                if (userBooking.getStatus() == Booking.Booked.PENDING) {
+                    throw new BusinessException("결제중인 내역이 있습니다.", "PAYMENT_IN_PROGRESS");
                 } else {
-                    if (userBooking.getStatus() == Booking.Booked.PENDING) {
-                        throw new BusinessException("결제중인 내역이 있습니다.", "PAYMENT_IN_PROGRESS");
-                    } else {
-                        throw new BusinessException("1인 1매만 가능합니다.", "BOOKING_ONE_PER_EVENT");
-                    }
+                    throw new BusinessException("1인 1매만 가능합니다.", "BOOKING_ONE_PER_EVENT");
                 }
-            } else {
-                return createNewBooking(request, accountId);
             }
-        } catch (BusinessException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new BusinessException("예약을 처리할 수 없습니다.", "BOOKING_PROCESS_ERROR");
-        }
-    }
-    
-    private BookingResponse createNewBooking(BookingRequest request, Long accountId) {
-        try {
+            
             List<Booking> existingSeatBookings = bookingRepository.findAllByEventScheduleIdAndSeatId(
                     request.getEventScheduleId(), 
                     request.getSeatId()
@@ -165,13 +152,48 @@ public class BookingService {
             
             bookingRepository.save(newBooking);
             return new BookingResponse(newBooking.getEventScheduleId(), newBooking.getBookingId());
+            
         } catch (BusinessException e) {
             throw e;
         } catch (Exception e) {
-            throw new BusinessException("새 예약을 생성할 수 없습니다.", "BOOKING_CREATE_ERROR");
+            throw new BusinessException("예약을 처리할 수 없습니다.", "BOOKING_PROCESS_ERROR");
+        }
+    }
+
+    // 예매 취소
+    @Transactional
+    public void cancelBooking(Long eventScheduleId, Long accountId) {
+        try {
+            if (eventScheduleId == null) {
+                throw new BusinessException("이벤트 스케줄 ID가 필요합니다.", "INVALID_EVENT_SCHEDULE_ID");
+            }
+            if (accountId == null) {
+                throw new BusinessException("계정 ID가 필요합니다.", "INVALID_ACCOUNT_ID");
+            }
+            
+            Optional<Booking> bookingOpt = bookingRepository.findActiveBookingByEventScheduleIdAndAccountId(
+                    eventScheduleId, 
+                    accountId
+            );
+            
+            if (bookingOpt.isEmpty()) {
+                throw new BusinessException("취소할 예약을 찾을 수 없습니다.", "BOOKING_NOT_FOUND");
+            }
+            
+            Booking booking = bookingOpt.get();
+            if (booking.getStatus() != Booking.Booked.BOOKED) {
+                throw new BusinessException("BOOKED 상태의 예약만 취소할 수 있습니다.", "INVALID_BOOKING_STATUS");
+            }
+            
+            updateBookingStatus(booking.getBookingId(), Booking.Booked.CANCELED, null);
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException("예약 취소를 처리할 수 없습니다.", "BOOKING_CANCEL_ERROR");
         }
     }
     
+    // PENDING 예약 삭제 스케줄러
     @Transactional(readOnly = false)
     @Scheduled(cron = "0 */5 * * * *")
     public void deletePendingBookings() {
@@ -190,6 +212,7 @@ public class BookingService {
         }
     }
     
+    // kafka -> 예약 상태 업데이트
     @Transactional
     public void updateBookingStatus(Long bookingId, Booking.Booked status, Long paymentId) {
         try {

--- a/booking/src/main/java/com/pyokemon/booking/service/BookingService.java
+++ b/booking/src/main/java/com/pyokemon/booking/service/BookingService.java
@@ -187,11 +187,46 @@ public class BookingService {
                 throw new BusinessException("BOOKED 상태의 예약만 취소할 수 있습니다.", "INVALID_BOOKING_STATUS");
             }
             
-            updateBookingStatus(booking.getBookingId(), Booking.Booked.CANCELED, null);
+            booking.setStatus(Booking.Booked.CANCELED);
+            booking.setUpdatedAt(LocalDateTime.now());
+            bookingRepository.save(booking);
         } catch (BusinessException e) {
             throw e;
         } catch (Exception e) {
             throw new BusinessException("예약 취소를 처리할 수 없습니다.", "BOOKING_CANCEL_ERROR");
+        }
+    }
+    
+    // 예약 상태 업데이트 (결제 이벤트 처리용)
+    @Transactional
+    public void updateBookingStatus(Long bookingId, Booking.Booked newStatus, Long paymentId) {
+        try {
+            if (bookingId == null) {
+                throw new BusinessException("예약 ID가 필요합니다.", "INVALID_BOOKING_ID");
+            }
+            if (newStatus == null) {
+                throw new BusinessException("예약 상태가 필요합니다.", "INVALID_BOOKING_STATUS");
+            }
+            
+            Optional<Booking> bookingOpt = bookingRepository.findById(bookingId);
+            if (bookingOpt.isEmpty()) {
+                throw new BusinessException("예약을 찾을 수 없습니다.", "BOOKING_NOT_FOUND");
+            }
+            
+            Booking booking = bookingOpt.get();
+            booking.setStatus(newStatus);
+            booking.setPaymentId(paymentId);
+            booking.setUpdatedAt(LocalDateTime.now());
+            
+            bookingRepository.save(booking);
+            
+            log.info("예약 상태 업데이트 완료: bookingId={}, status={}, paymentId={}", 
+                    bookingId, newStatus, paymentId);
+                    
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException("예약 상태 업데이트를 처리할 수 없습니다.", "BOOKING_STATUS_UPDATE_ERROR");
         }
     }
     
@@ -213,5 +248,4 @@ public class BookingService {
             log.error("PENDING 예약 삭제 작업 중 오류 발생", e);
         }
     }
-  }
 }

--- a/booking/src/main/resources/db/migration/booking/V1_001__Create_booking_table.sql
+++ b/booking/src/main/resources/db/migration/booking/V1_001__Create_booking_table.sql
@@ -3,11 +3,9 @@ CREATE TABLE tb_booking (
     event_schedule_id BIGINT NOT NULL,
     seat_id BIGINT NOT NULL,
     account_id BIGINT NOT NULL,
+    tenant_id BIGINT NOT NULL,
     payment_id BIGINT,
     status ENUM('PENDING', 'BOOKED', 'CANCELED', 'FAILED') DEFAULT 'PENDING',
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    INDEX idx_event_schedule_id (event_schedule_id),
-    INDEX idx_account_id (account_id),
-    INDEX idx_payment_id (payment_id)
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/booking/src/main/resources/mapper/BookingMapper.xml
+++ b/booking/src/main/resources/mapper/BookingMapper.xml
@@ -45,6 +45,21 @@
         WHERE status = 'PENDING'
     </select>
 
+    <select id="findValidBookingsWithEventInfo" resultType="com.pyokemon.booking.dto.response.ValidBookingDetail">
+        SELECT 
+            b.booking_id as bookingId,
+            es.event_id as eventId,
+            b.tenant_id as tenantId
+        FROM tb_booking b
+        INNER JOIN tb_event_schedule es ON b.event_schedule_id = es.event_schedule_id
+        WHERE b.account_id = #{accountId}
+        AND b.status = 'BOOKED'
+        AND b.booking_id IN
+        <foreach collection="bookingIds" item="bookingId" open="(" separator="," close=")">
+            #{bookingId}
+        </foreach>
+    </select>
+
     <insert id="save" parameterType="Booking" useGeneratedKeys="true" keyProperty="bookingId">
         INSERT INTO tb_booking (event_schedule_id, seat_id, account_id, tenant_id, payment_id, status, created_at, updated_at)
         VALUES (#{eventScheduleId}, #{seatId}, #{accountId}, #{tenantId}, #{paymentId}, #{status}, #{createdAt}, #{updatedAt})

--- a/booking/src/main/resources/mapper/BookingMapper.xml
+++ b/booking/src/main/resources/mapper/BookingMapper.xml
@@ -48,10 +48,9 @@
     <select id="findValidBookingsWithEventInfo" resultType="com.pyokemon.booking.dto.response.ValidBookingDetail">
         SELECT 
             b.booking_id as bookingId,
-            es.event_id as eventId,
+            b.event_schedule_id as eventScheduleId,
             b.tenant_id as tenantId
         FROM tb_booking b
-        INNER JOIN tb_event_schedule es ON b.event_schedule_id = es.event_schedule_id
         WHERE b.account_id = #{accountId}
         AND b.status = 'BOOKED'
         AND b.booking_id IN

--- a/booking/src/main/resources/mapper/BookingMapper.xml
+++ b/booking/src/main/resources/mapper/BookingMapper.xml
@@ -13,20 +13,20 @@
     </select>
 
     <select id="findByAccountId" resultType="Booking">
-        SELECT booking_id, event_schedule_id, seat_id, account_id, payment_id, status, created_at, updated_at
+        SELECT booking_id, event_schedule_id, seat_id, account_id, tenant_id, payment_id, status, created_at, updated_at
         FROM tb_booking
         WHERE account_id = #{accountId}
     </select>
 
     <select id="findAllByEventScheduleIdAndSeatId" resultType="Booking">
-        SELECT booking_id, event_schedule_id, seat_id, account_id, payment_id, status, created_at, updated_at
+        SELECT booking_id, event_schedule_id, seat_id, account_id, tenant_id, payment_id, status, created_at, updated_at
         FROM tb_booking
         WHERE event_schedule_id = #{eventScheduleId} AND seat_id = #{seatId}
         ORDER BY created_at DESC
     </select>
 
     <select id="findActiveBookingByEventScheduleIdAndAccountId" resultType="Booking">
-        SELECT booking_id, event_schedule_id, seat_id, account_id, payment_id, status, created_at, updated_at
+        SELECT booking_id, event_schedule_id, seat_id, account_id, tenant_id, payment_id, status, created_at, updated_at
         FROM tb_booking
         WHERE event_schedule_id = #{eventScheduleId} AND account_id = #{accountId}
         AND status IN ('PENDING', 'BOOKED')
@@ -34,20 +34,20 @@
     </select>
 
     <select id="findById" resultType="Booking">
-        SELECT booking_id, event_schedule_id, seat_id, account_id, payment_id, status, created_at, updated_at
+        SELECT booking_id, event_schedule_id, seat_id, account_id, tenant_id, payment_id, status, created_at, updated_at
         FROM tb_booking
         WHERE booking_id = #{bookingId}
     </select>
 
     <select id="findPendingBookings" resultType="Booking">
-        SELECT booking_id, event_schedule_id, seat_id, account_id, payment_id, status, created_at, updated_at
+        SELECT booking_id, event_schedule_id, seat_id, account_id, tenant_id, payment_id, status, created_at, updated_at
         FROM tb_booking
         WHERE status = 'PENDING'
     </select>
 
     <insert id="save" parameterType="Booking" useGeneratedKeys="true" keyProperty="bookingId">
-        INSERT INTO tb_booking (event_schedule_id, seat_id, account_id, payment_id, status, created_at, updated_at)
-        VALUES (#{eventScheduleId}, #{seatId}, #{accountId}, #{paymentId}, #{status}, #{createdAt}, #{updatedAt})
+        INSERT INTO tb_booking (event_schedule_id, seat_id, account_id, tenant_id, payment_id, status, created_at, updated_at)
+        VALUES (#{eventScheduleId}, #{seatId}, #{accountId}, #{tenantId}, #{paymentId}, #{status}, #{createdAt}, #{updatedAt})
     </insert>
 
     <update id="update" parameterType="Booking">

--- a/booking/src/test/booking.postman_collection.json
+++ b/booking/src/test/booking.postman_collection.json
@@ -60,6 +60,9 @@
 		{
 			"name": "공연 예매 내역 조회",
 			"request": {
+				"auth": {
+					"type": "noauth"
+				},
 				"method": "GET",
 				"header": [
 					{
@@ -79,7 +82,7 @@
 					}
 				],
 				"url": {
-					"raw": "http://localhost:8088/booking/api/bookings/2",
+					"raw": "http://localhost:8088/booking/api/bookings/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
@@ -89,7 +92,7 @@
 						"booking",
 						"api",
 						"bookings",
-						"2"
+						"1"
 					]
 				}
 			},
@@ -99,28 +102,91 @@
 			"name": "사용자 예매 내역 조회",
 			"request": {
 				"auth": {
-					"type": "noauth"
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3NTQ2MzEyNTEsImV4cCI6MTc1NDYzMzA1MX0.qA8DMbh7u-2n9O7kLcCIubv8hJRWFTd_N8tcAmFtfHg",
+							"type": "string"
+						}
+					]
 				},
 				"method": "GET",
 				"header": [
 					{
 						"key": "X-Auth-AccountId",
 						"value": "2",
-						"type": "text"
+						"type": "text",
+						"disabled": true
 					},
 					{
 						"key": "X-Auth-Role",
 						"value": "USER",
-						"type": "text"
+						"type": "text",
+						"disabled": true
 					},
 					{
 						"key": "Content-Type",
 						"value": "application/json",
-						"type": "text"
+						"type": "text",
+						"disabled": true
 					}
 				],
 				"url": {
-					"raw": "http://localhost:8088/booking/api/bookings/account",
+					"raw": "http://localhost:8087/booking/api/bookings/account",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8087",
+					"path": [
+						"booking",
+						"api",
+						"bookings",
+						"account"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "유효 예매 확인",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "X-Auth-AccountId",
+						"value": "1",
+						"type": "text",
+						"disabled": true
+					},
+					{
+						"key": "X-Auth-Role",
+						"value": "USER",
+						"type": "text",
+						"disabled": true
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text",
+						"disabled": true
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n\t\"userId\": 8,\r\n\t\"bookings\" : [3, 4, 5, 6, 7]\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8088/booking/backend/validbookings",
 					"protocol": "http",
 					"host": [
 						"localhost"
@@ -128,9 +194,8 @@
 					"port": "8088",
 					"path": [
 						"booking",
-						"api",
-						"bookings",
-						"account"
+						"backend",
+						"validbookings"
 					]
 				}
 			},

--- a/booking/src/test/java/com/pyokemon/booking/controller/BookingControllerTest.java
+++ b/booking/src/test/java/com/pyokemon/booking/controller/BookingControllerTest.java
@@ -27,7 +27,9 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -138,10 +140,10 @@ class BookingControllerTest {
 
     @Test
     @DisplayName("예약 생성 성공")
-    void createOrUpdateBooking_Success() throws Exception {
+    void createBooking_Success() throws Exception {
         BookingResponse expectedResponse = new BookingResponse(validEventScheduleId, 1L);
         
-        when(bookingService.createOrUpdateBooking(any(BookingRequest.class), eq(validAccountId)))
+        when(bookingService.createBooking(any(BookingRequest.class), eq(validAccountId)))
                 .thenReturn(expectedResponse);
 
         mockMvc.perform(post("/api/bookings/booking")
@@ -155,13 +157,23 @@ class BookingControllerTest {
     }
 
     @Test
+    @DisplayName("예약 취소 성공")
+    void cancelBooking_Success() throws Exception {
+        doNothing().when(bookingService).cancelBooking(eq(validEventScheduleId), eq(validAccountId));
+
+        mockMvc.perform(delete("/api/bookings/booking/{eventScheduleId}", validEventScheduleId)
+                        .header("X-Auth-AccountId", validAccountId))
+                .andExpect(status().isOk());
+    }
+
+    @Test
     @DisplayName("예약 생성 - 잘못된 요청")
-    void createOrUpdateBooking_InvalidRequest() throws Exception {
+    void createBooking_InvalidRequest() throws Exception {
         BookingRequest invalidRequest = new BookingRequest();
         invalidRequest.setEventScheduleId(null);
         invalidRequest.setSeatId(null);
 
-        when(bookingService.createOrUpdateBooking(any(BookingRequest.class), eq(validAccountId)))
+        when(bookingService.createBooking(any(BookingRequest.class), eq(validAccountId)))
                 .thenThrow(new BusinessException("이벤트 스케줄 ID가 필요합니다.", "INVALID_EVENT_SCHEDULE_ID"));
 
         mockMvc.perform(post("/api/bookings/booking")
@@ -175,7 +187,7 @@ class BookingControllerTest {
 
     @Test
     @DisplayName("예약 생성 - 헤더 누락")
-    void createOrUpdateBooking_MissingHeader() throws Exception {
+    void createBooking_MissingHeader() throws Exception {
         mockMvc.perform(post("/api/bookings/booking")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(validRequest)))
@@ -184,7 +196,7 @@ class BookingControllerTest {
 
     @Test
     @DisplayName("예약 생성 - 잘못된 JSON")
-    void createOrUpdateBooking_InvalidJson() throws Exception {
+    void createBooking_InvalidJson() throws Exception {
         mockMvc.perform(post("/api/bookings/booking")
                         .header("X-Auth-AccountId", validAccountId)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -194,8 +206,8 @@ class BookingControllerTest {
 
     @Test
     @DisplayName("예약 생성 - 결제중인 내역 오류")
-    void createOrUpdateBooking_PaymentInProgress() throws Exception {
-        when(bookingService.createOrUpdateBooking(any(BookingRequest.class), eq(validAccountId)))
+    void createBooking_PaymentInProgress() throws Exception {
+        when(bookingService.createBooking(any(BookingRequest.class), eq(validAccountId)))
                 .thenThrow(new BusinessException("결제중인 내역이 있습니다.", "PAYMENT_IN_PROGRESS"));
 
         mockMvc.perform(post("/api/bookings/booking")
@@ -209,8 +221,8 @@ class BookingControllerTest {
 
     @Test
     @DisplayName("예약 생성 - 1인1매 제한 오류")
-    void createOrUpdateBooking_OnePerEventLimit() throws Exception {
-        when(bookingService.createOrUpdateBooking(any(BookingRequest.class), eq(validAccountId)))
+    void createBooking_OnePerEventLimit() throws Exception {
+        when(bookingService.createBooking(any(BookingRequest.class), eq(validAccountId)))
                 .thenThrow(new BusinessException("1인 1매만 가능합니다.", "BOOKING_ONE_PER_EVENT"));
 
         mockMvc.perform(post("/api/bookings/booking")
@@ -224,8 +236,8 @@ class BookingControllerTest {
 
     @Test
     @DisplayName("예약 생성 - 이미 예약된 좌석 오류")
-    void createOrUpdateBooking_SeatAlreadyBooked() throws Exception {
-        when(bookingService.createOrUpdateBooking(any(BookingRequest.class), eq(validAccountId)))
+    void createBooking_SeatAlreadyBooked() throws Exception {
+        when(bookingService.createBooking(any(BookingRequest.class), eq(validAccountId)))
                 .thenThrow(new BusinessException("이미 예약된 좌석입니다.", "SEAT_ALREADY_BOOKED"));
 
         mockMvc.perform(post("/api/bookings/booking")

--- a/booking/src/test/java/com/pyokemon/booking/controller/ValidBookingControllerTest.java
+++ b/booking/src/test/java/com/pyokemon/booking/controller/ValidBookingControllerTest.java
@@ -1,0 +1,143 @@
+package com.pyokemon.booking.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pyokemon.booking.dto.request.ValidBookingRequest;
+import com.pyokemon.booking.dto.response.ValidBookingDetail;
+import com.pyokemon.booking.dto.response.ValidBookingResponse;
+import com.pyokemon.booking.service.BookingService;
+import com.pyokemon.common.exception.BusinessException;
+import com.pyokemon.common.exception.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class ValidBookingControllerTest {
+
+    @Mock
+    private BookingService bookingService;
+
+    @InjectMocks
+    private ValidBookingController validBookingController;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    private ValidBookingRequest validRequest;
+    private ValidBookingResponse validResponse;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(validBookingController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+        objectMapper = new ObjectMapper();
+
+        validRequest = ValidBookingRequest.builder()
+                .userId(398413L)
+                .bookings(Arrays.asList(12312341L, 12431231L, 141231L))
+                .build();
+
+        List<ValidBookingDetail> bookingDetails = Arrays.asList(
+                ValidBookingDetail.builder()
+                        .bookingId(12312341L)
+                        .eventScheduleId(101L)
+                        .tenantId(201L)
+                        .build(),
+                ValidBookingDetail.builder()
+                        .bookingId(12431231L)
+                        .eventScheduleId(102L)
+                        .tenantId(202L)
+                        .build()
+        );
+
+        validResponse = ValidBookingResponse.builder()
+                .bookings(bookingDetails)
+                .build();
+    }
+
+    @Test
+    @DisplayName("유효한 예약 검증 API 테스트 - 성공")
+    void validateBookings_Success() throws Exception {
+        when(bookingService.validateBookings(any(ValidBookingRequest.class)))
+                .thenReturn(validResponse);
+
+        mockMvc.perform(post("/backend/validbookings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.bookings").isArray())
+                .andExpect(jsonPath("$.bookings.length()").value(2))
+                .andExpect(jsonPath("$.bookings[0].bookingId").value(12312341))
+                .andExpect(jsonPath("$.bookings[0].eventScheduleId").value(101))
+                .andExpect(jsonPath("$.bookings[0].tenantId").value(201))
+                .andExpect(jsonPath("$.bookings[1].bookingId").value(12431231))
+                .andExpect(jsonPath("$.bookings[1].eventScheduleId").value(102))
+                .andExpect(jsonPath("$.bookings[1].tenantId").value(202));
+    }
+
+    @Test
+    @DisplayName("유효한 예약 검증 API 테스트 - 빈 예약 목록")
+    void validateBookings_EmptyBookings() throws Exception {
+        ValidBookingRequest emptyRequest = ValidBookingRequest.builder()
+                .userId(398413L)
+                .bookings(List.of())
+                .build();
+
+        ValidBookingResponse emptyResponse = ValidBookingResponse.builder()
+                .bookings(List.of())
+                .build();
+
+        when(bookingService.validateBookings(any(ValidBookingRequest.class)))
+                .thenReturn(emptyResponse);
+
+        mockMvc.perform(post("/backend/validbookings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(emptyRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.bookings").isArray())
+                .andExpect(jsonPath("$.bookings.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("유효한 예약 검증 API 테스트 - 잘못된 요청")
+    void validateBookings_InvalidRequest() throws Exception {
+        ValidBookingRequest invalidRequest = ValidBookingRequest.builder()
+                .userId(null)
+                .bookings(Arrays.asList(12312341L, 12431231L))
+                .build();
+
+        when(bookingService.validateBookings(any(ValidBookingRequest.class)))
+                .thenThrow(new BusinessException("사용자 ID가 필요합니다.", "INVALID_USER_ID"));
+
+        mockMvc.perform(post("/backend/validbookings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("INVALID_USER_ID"));
+    }
+
+    @Test
+    @DisplayName("유효한 예약 검증 API 테스트 - 잘못된 JSON")
+    void validateBookings_InvalidJson() throws Exception {
+        mockMvc.perform(post("/backend/validbookings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("invalid json"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/booking/src/test/java/com/pyokemon/booking/service/BookingServiceTest.java
+++ b/booking/src/test/java/com/pyokemon/booking/service/BookingServiceTest.java
@@ -127,7 +127,7 @@ class BookingServiceTest {
 
     @Test
     @DisplayName("새 예약 생성 성공")
-    void createOrUpdateBooking_NewBooking_Success() {
+    void createBooking_NewBooking_Success() {
         when(bookingRepository.findActiveBookingByEventScheduleIdAndAccountId(validEventScheduleId, validAccountId))
                 .thenReturn(Optional.empty());
         when(bookingRepository.findAllByEventScheduleIdAndSeatId(validEventScheduleId, validSeatId))
@@ -138,7 +138,7 @@ class BookingServiceTest {
             return null;
         }).when(bookingRepository).save(any(Booking.class));
 
-        BookingResponse response = bookingService.createOrUpdateBooking(validRequest, validAccountId);
+        BookingResponse response = bookingService.createBooking(validRequest, validAccountId);
 
         assertNotNull(response);
         assertEquals(validEventScheduleId, response.getEventScheduleId());
@@ -147,28 +147,14 @@ class BookingServiceTest {
     }
 
     @Test
-    @DisplayName("같은 좌석 취소 성공")
-    void createOrUpdateBooking_SameSeat_CancelSuccess() {
-        Booking existingBooking = createBooking(validSeatId, Booking.Booked.PENDING);
-        when(bookingRepository.findActiveBookingByEventScheduleIdAndAccountId(validEventScheduleId, validAccountId))
-                .thenReturn(Optional.of(existingBooking));
-
-        BookingResponse response = bookingService.createOrUpdateBooking(validRequest, validAccountId);
-
-        assertNotNull(response);
-        assertEquals(validEventScheduleId, response.getEventScheduleId());
-        verify(bookingRepository).update(any(Booking.class));
-    }
-
-    @Test
     @DisplayName("다른 좌석 예약 시도 - PENDING 상태")
-    void createOrUpdateBooking_DifferentSeat_PendingStatus() {
+    void createBooking_DifferentSeat_PendingStatus() {
         Booking existingBooking = createBooking(2L, Booking.Booked.PENDING);
         when(bookingRepository.findActiveBookingByEventScheduleIdAndAccountId(validEventScheduleId, validAccountId))
                 .thenReturn(Optional.of(existingBooking));
 
         BusinessException exception = assertThrows(BusinessException.class, () -> {
-            bookingService.createOrUpdateBooking(validRequest, validAccountId);
+            bookingService.createBooking(validRequest, validAccountId);
         });
         
         assertEquals("PAYMENT_IN_PROGRESS", exception.getErrorCode());
@@ -176,13 +162,13 @@ class BookingServiceTest {
 
     @Test
     @DisplayName("다른 좌석 예약 시도 - BOOKED 상태")
-    void createOrUpdateBooking_DifferentSeat_BookedStatus() {
+    void createBooking_DifferentSeat_BookedStatus() {
         Booking existingBooking = createBooking(2L, Booking.Booked.BOOKED);
         when(bookingRepository.findActiveBookingByEventScheduleIdAndAccountId(validEventScheduleId, validAccountId))
                 .thenReturn(Optional.of(existingBooking));
 
         BusinessException exception = assertThrows(BusinessException.class, () -> {
-            bookingService.createOrUpdateBooking(validRequest, validAccountId);
+            bookingService.createBooking(validRequest, validAccountId);
         });
         
         assertEquals("BOOKING_ONE_PER_EVENT", exception.getErrorCode());
@@ -190,7 +176,7 @@ class BookingServiceTest {
 
     @Test
     @DisplayName("이미 예약된 좌석 예약 시도")
-    void createOrUpdateBooking_AlreadyBookedSeat() {
+    void createBooking_AlreadyBookedSeat() {
         when(bookingRepository.findActiveBookingByEventScheduleIdAndAccountId(validEventScheduleId, validAccountId))
                 .thenReturn(Optional.empty());
         
@@ -199,7 +185,7 @@ class BookingServiceTest {
                 .thenReturn(Collections.singletonList(existingSeatBooking));
 
         BusinessException exception = assertThrows(BusinessException.class, () -> {
-            bookingService.createOrUpdateBooking(validRequest, validAccountId);
+            bookingService.createBooking(validRequest, validAccountId);
         });
         
         assertEquals("SEAT_ALREADY_BOOKED", exception.getErrorCode());
@@ -207,11 +193,11 @@ class BookingServiceTest {
 
     @Test
     @DisplayName("예약 생성 - null eventScheduleId")
-    void createOrUpdateBooking_NullEventScheduleId() {
+    void createBooking_NullEventScheduleId() {
         validRequest.setEventScheduleId(null);
 
         BusinessException exception = assertThrows(BusinessException.class, () -> {
-            bookingService.createOrUpdateBooking(validRequest, validAccountId);
+            bookingService.createBooking(validRequest, validAccountId);
         });
         
         assertEquals("INVALID_EVENT_SCHEDULE_ID", exception.getErrorCode());
@@ -219,11 +205,11 @@ class BookingServiceTest {
 
     @Test
     @DisplayName("예약 생성 - null seatId")
-    void createOrUpdateBooking_NullSeatId() {
+    void createBooking_NullSeatId() {
         validRequest.setSeatId(null);
 
         BusinessException exception = assertThrows(BusinessException.class, () -> {
-            bookingService.createOrUpdateBooking(validRequest, validAccountId);
+            bookingService.createBooking(validRequest, validAccountId);
         });
         
         assertEquals("INVALID_SEAT_ID", exception.getErrorCode());
@@ -231,12 +217,51 @@ class BookingServiceTest {
 
     @Test
     @DisplayName("예약 생성 - null accountId")
-    void createOrUpdateBooking_NullAccountId() {
+    void createBooking_NullAccountId() {
         BusinessException exception = assertThrows(BusinessException.class, () -> {
-            bookingService.createOrUpdateBooking(validRequest, null);
+            bookingService.createBooking(validRequest, null);
         });
         
         assertEquals("INVALID_ACCOUNT_ID", exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("예약 취소 성공")
+    void cancelBooking_Success() {
+        Booking existingBooking = createBooking(validSeatId, Booking.Booked.BOOKED);
+        when(bookingRepository.findActiveBookingByEventScheduleIdAndAccountId(validEventScheduleId, validAccountId))
+                .thenReturn(Optional.of(existingBooking));
+
+        bookingService.cancelBooking(validEventScheduleId, validAccountId);
+
+        verify(bookingRepository).update(any(Booking.class));
+    }
+
+    @Test
+    @DisplayName("예약 취소 - 예약을 찾을 수 없는 경우")
+    void cancelBooking_BookingNotFound() {
+        when(bookingRepository.findActiveBookingByEventScheduleIdAndAccountId(validEventScheduleId, validAccountId))
+                .thenReturn(Optional.empty());
+
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            bookingService.cancelBooking(validEventScheduleId, validAccountId);
+        });
+        
+        assertEquals("BOOKING_NOT_FOUND", exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("예약 취소 - PENDING 상태인 경우")
+    void cancelBooking_PendingStatus() {
+        Booking existingBooking = createBooking(validSeatId, Booking.Booked.PENDING);
+        when(bookingRepository.findActiveBookingByEventScheduleIdAndAccountId(validEventScheduleId, validAccountId))
+                .thenReturn(Optional.of(existingBooking));
+
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            bookingService.cancelBooking(validEventScheduleId, validAccountId);
+        });
+        
+        assertEquals("INVALID_BOOKING_STATUS", exception.getErrorCode());
     }
 
     @Test

--- a/booking/src/test/java/com/pyokemon/booking/service/BookingServiceTest.java
+++ b/booking/src/test/java/com/pyokemon/booking/service/BookingServiceTest.java
@@ -1,5 +1,23 @@
 package com.pyokemon.booking.service;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.pyokemon.booking.dto.request.BookingRequest;
 import com.pyokemon.booking.dto.request.ValidBookingRequest;
 import com.pyokemon.booking.dto.response.AccountIdResponse;
@@ -11,31 +29,14 @@ import com.pyokemon.booking.entity.Booking;
 import com.pyokemon.booking.repository.BookingRepository;
 import com.pyokemon.common.exception.BusinessException;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-
-import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-
 @ExtendWith(MockitoExtension.class)
 class BookingServiceTest {
   
     @Mock
     private BookingRepository bookingRepository;
+
+    @Mock
+    private BookingEventPublisher bookingEventPublisher;
 
     @InjectMocks
     private BookingService bookingService;
@@ -44,6 +45,7 @@ class BookingServiceTest {
     private Long validAccountId;
     private Long validEventScheduleId;
     private Long validSeatId;
+    private Long validTenantId;
     private ValidBookingRequest validBookingRequest;
     private List<ValidBookingDetail> mockBookingDetails;
 
@@ -52,10 +54,12 @@ class BookingServiceTest {
         validAccountId = 1L;
         validEventScheduleId = 1L;
         validSeatId = 1L;
+        validTenantId = 1L;
         
         validRequest = new BookingRequest();
         validRequest.setEventScheduleId(validEventScheduleId);
         validRequest.setSeatId(validSeatId);
+        validRequest.setTenantId(validTenantId);
 
         validBookingRequest = ValidBookingRequest.builder()
                 .userId(398413L)
@@ -176,10 +180,7 @@ class BookingServiceTest {
         assertEquals("BOOKING_ONE_PER_EVENT", exception.getErrorCode());
     }
 
-    assertEquals("BOOKING_ONE_PER_EVENT", exception.getErrorCode());
-  }
-
-  @Test
+    @Test
     @DisplayName("이미 예약된 좌석 예약 시도")
     void createBooking_AlreadyBookedSeat() {
         when(bookingRepository.findActiveBookingByEventScheduleIdAndAccountId(validEventScheduleId, validAccountId))
@@ -221,6 +222,18 @@ class BookingServiceTest {
     }
 
     @Test
+    @DisplayName("예약 생성 - null tenantId")
+    void createBooking_NullTenantId() {
+        validRequest.setTenantId(null);
+
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            bookingService.createBooking(validRequest, validAccountId);
+        });
+        
+        assertEquals("INVALID_TENANT_ID", exception.getErrorCode());
+    }
+
+    @Test
     @DisplayName("예약 생성 - null accountId")
     void createBooking_NullAccountId() {
         BusinessException exception = assertThrows(BusinessException.class, () -> {
@@ -239,7 +252,7 @@ class BookingServiceTest {
 
         bookingService.cancelBooking(validEventScheduleId, validAccountId);
 
-        verify(bookingRepository).update(any(Booking.class));
+        verify(bookingRepository).save(any(Booking.class));
     }
 
     @Test
@@ -270,6 +283,34 @@ class BookingServiceTest {
     }
 
     @Test
+    @DisplayName("예약 상태 업데이트 성공")
+    void updateBookingStatus_Success() {
+        Long bookingId = 1L;
+        Long paymentId = 100L;
+        Booking.Booked newStatus = Booking.Booked.BOOKED;
+        
+        Booking existingBooking = createBooking(validSeatId, Booking.Booked.PENDING);
+        when(bookingRepository.findById(bookingId)).thenReturn(Optional.of(existingBooking));
+
+        bookingService.updateBookingStatus(bookingId, newStatus, paymentId);
+
+        verify(bookingRepository).save(any(Booking.class));
+    }
+
+    @Test
+    @DisplayName("예약 상태 업데이트 - 예약을 찾을 수 없는 경우")
+    void updateBookingStatus_BookingNotFound() {
+        Long bookingId = 1L;
+        when(bookingRepository.findById(bookingId)).thenReturn(Optional.empty());
+
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            bookingService.updateBookingStatus(bookingId, Booking.Booked.BOOKED, 100L);
+        });
+        
+        assertEquals("BOOKING_NOT_FOUND", exception.getErrorCode());
+    }
+
+    @Test
     @DisplayName("PENDING 예약 삭제 성공")
     void deletePendingBookings_Success() {
         List<Booking> pendingBookings = Arrays.asList(
@@ -278,27 +319,10 @@ class BookingServiceTest {
         );
         when(bookingRepository.findPendingBookings()).thenReturn(pendingBookings);
 
-  @Test
-  @DisplayName("예약 생성 - null accountId")
-  void createOrUpdateBooking_NullAccountId() {
-    BusinessException exception = assertThrows(BusinessException.class, () -> {
-      bookingService.createOrUpdateBooking(validRequest, null);
-    });
+        bookingService.deletePendingBookings();
 
-    assertEquals("INVALID_ACCOUNT_ID", exception.getErrorCode());
-  }
-
-  @Test
-  @DisplayName("PENDING 예약 삭제 성공")
-  void deletePendingBookings_Success() {
-    List<Booking> pendingBookings = Arrays.asList(createBooking(1L, Booking.Booked.PENDING),
-        createBooking(2L, Booking.Booked.PENDING));
-    when(bookingRepository.findPendingBookings()).thenReturn(pendingBookings);
-
-    bookingService.deletePendingBookings();
-
-    verify(bookingRepository, times(2)).delete(anyLong());
-  }
+        verify(bookingRepository, times(2)).delete(anyLong());
+    }
 
     @Test
     @DisplayName("PENDING 예약 삭제 - 빈 리스트")
@@ -395,6 +419,7 @@ class BookingServiceTest {
                 .eventScheduleId(validEventScheduleId)
                 .seatId(seatId)
                 .accountId(validAccountId)
+                .tenantId(validTenantId)
                 .paymentId(null)
                 .status(status)
                 .createdAt(LocalDateTime.now())

--- a/booking/src/test/java/com/pyokemon/booking/service/BookingServiceTest.java
+++ b/booking/src/test/java/com/pyokemon/booking/service/BookingServiceTest.java
@@ -1,9 +1,12 @@
 package com.pyokemon.booking.service;
 
 import com.pyokemon.booking.dto.request.BookingRequest;
+import com.pyokemon.booking.dto.request.ValidBookingRequest;
 import com.pyokemon.booking.dto.response.AccountIdResponse;
 import com.pyokemon.booking.dto.response.BookingResponse;
 import com.pyokemon.booking.dto.response.EventScheduleIdResponse;
+import com.pyokemon.booking.dto.response.ValidBookingDetail;
+import com.pyokemon.booking.dto.response.ValidBookingResponse;
 import com.pyokemon.booking.entity.Booking;
 import com.pyokemon.booking.repository.BookingRepository;
 import com.pyokemon.common.exception.BusinessException;
@@ -38,6 +41,8 @@ class BookingServiceTest {
     private Long validAccountId;
     private Long validEventScheduleId;
     private Long validSeatId;
+    private ValidBookingRequest validBookingRequest;
+    private List<ValidBookingDetail> mockBookingDetails;
 
     @BeforeEach
     void setUp() {
@@ -48,6 +53,25 @@ class BookingServiceTest {
         validRequest = new BookingRequest();
         validRequest.setEventScheduleId(validEventScheduleId);
         validRequest.setSeatId(validSeatId);
+
+        // ValidBooking 테스트용 데이터
+        validBookingRequest = ValidBookingRequest.builder()
+                .userId(398413L)
+                .bookings(Arrays.asList(12312341L, 12431231L, 141231L))
+                .build();
+
+        mockBookingDetails = Arrays.asList(
+                ValidBookingDetail.builder()
+                        .bookingId(12312341L)
+                        .eventScheduleId(101L)
+                        .tenantId(201L)
+                        .build(),
+                ValidBookingDetail.builder()
+                        .bookingId(12431231L)
+                        .eventScheduleId(102L)
+                        .tenantId(202L)
+                        .build()
+        );
     }
 
     @Test
@@ -237,6 +261,85 @@ class BookingServiceTest {
         bookingService.deletePendingBookings();
 
         verify(bookingRepository, never()).delete(anyLong());
+    }
+
+    @Test
+    @DisplayName("유효한 예약 검증 - 성공")
+    void validateBookings_Success() {
+        when(bookingRepository.findValidBookingsWithEventInfo(
+                eq(validBookingRequest.getBookings()), 
+                eq(validBookingRequest.getUserId())))
+                .thenReturn(mockBookingDetails);
+
+        ValidBookingResponse response = bookingService.validateBookings(validBookingRequest);
+
+        assertNotNull(response);
+        assertEquals(2, response.getBookings().size());
+        assertEquals(12312341L, response.getBookings().get(0).getBookingId());
+        assertEquals(101L, response.getBookings().get(0).getEventScheduleId());
+        assertEquals(201L, response.getBookings().get(0).getTenantId());
+        verify(bookingRepository).findValidBookingsWithEventInfo(
+                validBookingRequest.getBookings(), 
+                validBookingRequest.getUserId());
+    }
+
+    @Test
+    @DisplayName("유효한 예약 검증 - 빈 결과")
+    void validateBookings_EmptyResult() {
+        when(bookingRepository.findValidBookingsWithEventInfo(
+                eq(validBookingRequest.getBookings()), 
+                eq(validBookingRequest.getUserId())))
+                .thenReturn(Collections.emptyList());
+
+        ValidBookingResponse response = bookingService.validateBookings(validBookingRequest);
+
+        assertNotNull(response);
+        assertTrue(response.getBookings().isEmpty());
+    }
+
+    @Test
+    @DisplayName("유효한 예약 검증 - userId가 null인 경우")
+    void validateBookings_UserIdNull() {
+        ValidBookingRequest invalidRequest = ValidBookingRequest.builder()
+                .userId(null)
+                .bookings(Arrays.asList(12312341L, 12431231L))
+                .build();
+
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            bookingService.validateBookings(invalidRequest);
+        });
+        
+        assertEquals("INVALID_USER_ID", exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("유효한 예약 검증 - bookings가 null인 경우")
+    void validateBookings_BookingsNull() {
+        ValidBookingRequest invalidRequest = ValidBookingRequest.builder()
+                .userId(398413L)
+                .bookings(null)
+                .build();
+
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            bookingService.validateBookings(invalidRequest);
+        });
+        
+        assertEquals("INVALID_BOOKING_IDS", exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("유효한 예약 검증 - bookings가 빈 리스트인 경우")
+    void validateBookings_BookingsEmpty() {
+        ValidBookingRequest invalidRequest = ValidBookingRequest.builder()
+                .userId(398413L)
+                .bookings(Collections.emptyList())
+                .build();
+
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            bookingService.validateBookings(invalidRequest);
+        });
+        
+        assertEquals("INVALID_BOOKING_IDS", exception.getErrorCode());
     }
 
     private Booking createBooking(Long seatId, Booking.Booked status) {


### PR DESCRIPTION
## ✏️ 작업 개요  
유효 예약건 확인 및 예약 등록/취소 로직 수정

## 🔨 작업 내용 상세
- 유효 예약건 확인: accountId(=userId)/bookingIds 중 BOOKED된 bookingId 만 반환
- 예약 로직 수정: 기존엔 동일 등록건 한번 더 post시 취소 / 수정 후엔 등록 로직과 취소 로직을 분리. 따로따로 요청

## 🔗 관련 이슈  
- Closes #89 

## ✅ 체크리스트  
- [ ] 테스트 코드 작성 완료
- [ ] 로컬에서 기능 정상 작동 확인
- [ ] 예외 처리 및 ResponseDto 적용
- [ ] 공통 모듈(공통 DTO, Exception 등) 사용 지침 준수
- [ ] Google Java Style Guide 및 네이밍 규칙 준수

## 💬 기타 참고 사항  
- DB 수정됨(tenantId 추가) -> 초기 실행시 다 drop 후 실행
- kafka 테스트 ok
