### PR TITLE
fix/PYOKEMON-145-공연 등록시 redis 초기화

### DIFF
--- a/event/src/main/java/com/pyokemon/event/service/TenantEventService.java
+++ b/event/src/main/java/com/pyokemon/event/service/TenantEventService.java
@@ -135,6 +135,9 @@ public class TenantEventService {
 
         Long eventScheduleId = saveEventSchedule(eventSchedule);
 
+        // 공연 등록 시 좌석 상태를 Redis에 초기화
+        seatStatusInitService.initSeatStatuses(eventScheduleId);
+
         // Save prices if present
         if (scheduleDto.getPrices() != null) {
           for (PriceDto priceDto : scheduleDto.getPrices()) {


### PR DESCRIPTION
## ✏️ 작업 개요  
공연 등록 시에 자동으로 redis 좌석 상태 초기화 되도록
registerEvent 메서드에 initSeatStatuses 추가

## 🔨 작업 내용 상세
- TenantEventService.java에 initSeatStatuses 추가

## 🔗 관련 이슈  
- Closes #이슈번호

## ✅ 체크리스트  
- [ ] 테스트 코드 작성 완료
- [ ] 로컬에서 기능 정상 작동 확인
- [ ] Swagger UI에서 API 확인 완료
- [ ] 예외 처리 및 ResponseDto 적용
- [ ] 공통 모듈(공통 DTO, Exception 등) 사용 지침 준수
- [ ] Google Java Style Guide 및 네이밍 규칙 준수
- [ ] Flyway 마이그레이션 파일 작성 (필요 시)


## 💬 기타 참고 사항  
- 리뷰어가 참고하면 좋을 만한 내용 (예: 테스트 방법, 의도된 예외 처리 등)
