### PR TITLE
[Feature/#162] 이벤트 2시간 전에 schedule id kafka pub하기

### DIFF
--- a/common/src/main/java/com/pyokemon/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/pyokemon/common/kafka/KafkaTopicConstants.java
@@ -5,4 +5,5 @@ public class KafkaTopicConstants {
   public static final String BOOKING_STATUS_UPDATED = "booking-status-updated";
   public static final String EVENT_STATUS_UPDATED = "event-status-updated";
   public static final String NOTIFICATION_REQUEST = "notification-request";
+  public static final String  EVENT_SCHEDULE_2H_AHEAD= "event-schedule-2h-ahead";
 }

--- a/event/src/main/java/com/pyokemon/event/dto/kafka/EventKafkaDto.java
+++ b/event/src/main/java/com/pyokemon/event/dto/kafka/EventKafkaDto.java
@@ -12,5 +12,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class EventKafkaDto {
   private Long eventScheduleId;
-  private String status;;
+  private String status;
 }

--- a/event/src/main/java/com/pyokemon/event/producer/KafkaMessageProducer.java
+++ b/event/src/main/java/com/pyokemon/event/producer/KafkaMessageProducer.java
@@ -23,4 +23,9 @@ public class KafkaMessageProducer {
         String.valueOf(dto.getEventScheduleId()), dto);
   }
 
+  public void sendTwoHoursBeforeEvent(Long eventScheduleId){
+    kafkaMessageSender.send(KafkaTopicConstants.EVENT_SCHEDULE_2H_AHEAD, String.valueOf(eventScheduleId), eventScheduleId);
+  }
+
+
 }

--- a/event/src/main/java/com/pyokemon/event/repository/EventScheduleRepository.java
+++ b/event/src/main/java/com/pyokemon/event/repository/EventScheduleRepository.java
@@ -32,4 +32,6 @@ public interface EventScheduleRepository {
   int updateEventSchedule(EventSchedule eventSchedule);
 
   Long findVenueIdByEventScheduleId(Long eventScheduleId);
+
+  List<Long> findEventScheduleIdTwoHoursLater();
 }

--- a/event/src/main/java/com/pyokemon/event/service/EventScheduleService.java
+++ b/event/src/main/java/com/pyokemon/event/service/EventScheduleService.java
@@ -4,6 +4,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.pyokemon.event.producer.KafkaMessageProducer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import com.pyokemon.event.dto.BookingInfoResponseDTO;
@@ -24,6 +27,7 @@ import com.pyokemon.event.service.RedisService;
 
 import lombok.RequiredArgsConstructor;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EventScheduleService {
@@ -33,6 +37,7 @@ public class EventScheduleService {
   private final SeatRepository seatRepository;
   private final SeatClassRepository seatClassRepository;
   private final RedisService redisService;
+  private final KafkaMessageProducer kafkaMessageProducer;
 
   public List<EventItemResponseDTO> getTodayOpenedTickets() {
     return eventScheduleRepository.selectTodayOpenedTickets();
@@ -132,5 +137,16 @@ public class EventScheduleService {
             .row(seat.getRow()).seatGrade(seatClass.getClassName()).build())
         .collect(Collectors.toList());
   }
+
+
+  @Scheduled(fixedRate = 5 * 60 * 1000)
+  public void publishTwoHoursAheadEvents(){
+    List<Long> upcomingIds = eventScheduleRepository.findEventScheduleIdTwoHoursLater();
+    for(Long id:upcomingIds){
+      log.info("Publishing eventScheduleId={} to Kafka", id);
+      kafkaMessageProducer.sendTwoHoursBeforeEvent(id);
+    }
+  }
+
 
 }

--- a/event/src/main/resources/mapper/EventScheduleMapper.xml
+++ b/event/src/main/resources/mapper/EventScheduleMapper.xml
@@ -148,4 +148,12 @@
     </select>
 
 
+    <select id="findEventScheduleIdTwoHoursLater" resultType="Long">
+        SELECT event_schedule_id
+        FROM tb_event_schedule
+        WHERE event_date BETWEEN CONVERT_TZ(NOW(), '+00:00', '+09:00') + INTERVAL 2 HOUR
+        AND CONVERT_TZ(NOW(), '+00:00', '+09:00') + INTERVAL 2 HOUR + INTERVAL 5 MINUTE;
+    </select>
+
+
 </mapper>


### PR DESCRIPTION
## ✏️ 작업 개요  
이번 PR에서 작업한 내용을 간단히 요약해주세요.

## 🔨 작업 내용 상세
- `EventScheduleService`에 스케줄링하는 `publishTwoHoursAheadEvents` 추가
- kafka topic `EVENT_SCHEDULE_2H_AHEAD` 추가
- `KafkaMessageProducer`에 `sendTwoHoursBeforeEvent` 추가
- `EventServiceRepository`에 `findEventScheduleIdTwoHoursLater` 추가

## 🔗 관련 이슈  
- Closes #이슈번호
- #162 

## ✅ 체크리스트  
- [ ] 테스트 코드 작성 완료
- [ ] 로컬에서 기능 정상 작동 확인
- [ ] Swagger UI에서 API 확인 완료
- [ ] 예외 처리 및 ResponseDto 적용
- [ ] 공통 모듈(공통 DTO, Exception 등) 사용 지침 준수
- [ ] Google Java Style Guide 및 네이밍 규칙 준수
- [ ] Flyway 마이그레이션 파일 작성 (필요 시)


## 💬 기타 참고 사항  
- 리뷰어가 참고하면 좋을 만한 내용 (예: 테스트 방법, 의도된 예외 처리 등)

현재 시간 + 2시간 ~ 현재 시간 + 2시간 5분 사이에 시작되는 공연의 event schedule id를 publish 합니다.

<img width="989" height="72" alt="image" src="https://github.com/user-attachments/assets/b7232c2f-7874-46cf-bbb6-502f9b609e0b" />

