### PR TITLE
Feature/#225/pyokemon 211 shedlock 적용

### DIFF
--- a/booking/build.gradle
+++ b/booking/build.gradle
@@ -18,6 +18,11 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers:1.19.3'
     testImplementation 'org.testcontainers:kafka:1.19.3'
     testImplementation 'org.testcontainers:junit-jupiter:1.19.3'
+
+    // Shedlock
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.15.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.15.0'
+
 }
 
 tasks.named('test') {

--- a/booking/src/main/java/com/pyokemon/booking/BookingApplication.java
+++ b/booking/src/main/java/com/pyokemon/booking/BookingApplication.java
@@ -1,5 +1,6 @@
 package com.pyokemon.booking;
 
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -9,6 +10,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication(scanBasePackages = {"com.pyokemon"})
 @MapperScan({"com.pyokemon.booking.repository", "com.pyokemon.booking.bff.repository"})
 @EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "10m")
 @EnableKafka
 public class BookingApplication {
   public static void main(String[] args) {

--- a/booking/src/main/java/com/pyokemon/booking/config/ShedLockConfig.java
+++ b/booking/src/main/java/com/pyokemon/booking/config/ShedLockConfig.java
@@ -1,0 +1,22 @@
+package com.pyokemon.booking.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class ShedLockConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+            JdbcTemplateLockProvider.Configuration.builder()
+                .withTableName("tb_shedlock")
+                .withJdbcTemplate(new org.springframework.jdbc.core.JdbcTemplate(dataSource))
+                .build()
+        );
+    }
+}

--- a/booking/src/main/java/com/pyokemon/booking/service/BookingService.java
+++ b/booking/src/main/java/com/pyokemon/booking/service/BookingService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -207,6 +208,11 @@ public class BookingService {
   // PENDING 예약 만료 처리 스케줄러 (1분마다 실행)
   @Transactional(readOnly = false)
   @Scheduled(cron = "0 */1 * * * *")
+  @SchedulerLock(
+          name = "expirePendingBookings", // 락 이름은 유니크하게
+          lockAtMostFor = "2m",  // 2분 이상 락 유지, 장애 시 중복 실행 방지
+          lockAtLeastFor = "1m"  // 최소 1분 락 유지, 중복 실행 방지
+  )
   public void expirePendingBookings() {
     try {
       LocalDateTime fiveMinutesAgo = LocalDateTime.now().minusMinutes(5);

--- a/booking/src/main/resources/db/migration/booking/V1_002__Create_shedlock_table.sql
+++ b/booking/src/main/resources/db/migration/booking/V1_002__Create_shedlock_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE tb_shedlock (
+    name VARCHAR(64) PRIMARY KEY,
+    lock_until TIMESTAMP NOT NULL,
+    locked_at TIMESTAMP NOT NULL,
+    locked_by VARCHAR(255) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/event/build.gradle
+++ b/event/build.gradle
@@ -17,6 +17,11 @@ dependencies {
     
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
+
+    // Shedlock
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.15.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.15.0'
+
 }
 
 tasks.named('test') {

--- a/event/src/main/java/com/pyokemon/event/EventApplication.java
+++ b/event/src/main/java/com/pyokemon/event/EventApplication.java
@@ -1,5 +1,6 @@
 package com.pyokemon.event;
 
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -10,6 +11,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication(scanBasePackages = {"com.pyokemon"})
 @MapperScan({"com.pyokemon.event.repository", "com.pyokemon.event.bff.repository"})
 @EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "10m")
 @EnableKafka
 @EnableFeignClients
 public class EventApplication {

--- a/event/src/main/java/com/pyokemon/event/config/ShedLockConfig.java
+++ b/event/src/main/java/com/pyokemon/event/config/ShedLockConfig.java
@@ -1,0 +1,22 @@
+package com.pyokemon.event.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class ShedLockConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+            JdbcTemplateLockProvider.Configuration.builder()
+                .withTableName("tb_shedlock")
+                .withJdbcTemplate(new org.springframework.jdbc.core.JdbcTemplate(dataSource))
+                .build()
+        );
+    }
+}

--- a/event/src/main/java/com/pyokemon/event/service/EventScheduleService.java
+++ b/event/src/main/java/com/pyokemon/event/service/EventScheduleService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -89,9 +90,9 @@ public class EventScheduleService {
   }
 
   private EventSchedule mapToEventSchedule(EventScheduleDto dto) {
-    EventSchedule eventSchedule = EventSchedule.builder().eventId(dto.getEventId())
-        .venueId(dto.getVenueId()).ticketOpenAt(dto.getTicketOpenAt()).eventDate(dto.getEventDate())
-        .build();
+    EventSchedule eventSchedule =
+        EventSchedule.builder().eventId(dto.getEventId()).venueId(dto.getVenueId())
+            .ticketOpenAt(dto.getTicketOpenAt()).eventDate(dto.getEventDate()).build();
     return eventSchedule;
   }
 
@@ -128,8 +129,7 @@ public class EventScheduleService {
     SeatClass seatClass = seatClassRepository.findByClassName(seatGradeName)
         .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 좌석 등급입니다: " + seatGradeName));
 
-    List<Seat> seats =
-        seatRepository.findByVenueIdAndSeatClassId(venueId, seatClass.getId());
+    List<Seat> seats = seatRepository.findByVenueIdAndSeatClassId(venueId, seatClass.getId());
 
     return seats.stream()
         .map(seat -> SeatInfoResponseDTO.builder().seatId(seat.getId()).col(seat.getCol())
@@ -139,6 +139,7 @@ public class EventScheduleService {
 
 
   @Scheduled(fixedRate = 5 * 60 * 1000)
+  @SchedulerLock(name = "publishTwoHoursAheadEvents", lockAtMostFor = "10m", lockAtLeastFor = "1m")
   public void publishTwoHoursAheadEvents() {
     List<Long> upcomingIds = eventScheduleRepository.findEventScheduleIdTwoHoursLater();
     for (Long id : upcomingIds) {

--- a/event/src/main/resources/db/migration/event/V1_015__Create_shedlock_table.sql
+++ b/event/src/main/resources/db/migration/event/V1_015__Create_shedlock_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE tb_shedlock (
+    name VARCHAR(64) PRIMARY KEY,
+    lock_until TIMESTAMP NOT NULL,
+    locked_at TIMESTAMP NOT NULL,
+    locked_by VARCHAR(255) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## ✏️ 작업 개요  
이번 PR에서 작업한 내용을 간단히 요약해주세요.
event, booking 서비스에 shedlock 추가

## 🔨 작업 내용 상세
- shedlock 테이블 생성
- build.gradle shedlock 의존성 추가
- Application에 @EnableSchedulerLock 추가
- 스케줄러 사용하는 Service에 @SchedulerLock 추가
- ShedlockConfig 작성

## 🔗 관련 이슈  
- Closes #이슈번호
#225 

## ✅ 체크리스트  


## 💬 기타 참고 사항  
- 리뷰어가 참고하면 좋을 만한 내용 (예: 테스트 방법, 의도된 예외 처리 등)
포트 여러개로 서비스 띄워봤을 때 db에 하나씩만 생성되는 것 확인했습니다. 
